### PR TITLE
Added configurable clock source, and improved timing

### DIFF
--- a/include/kernel/irq/action.h
+++ b/include/kernel/irq/action.h
@@ -12,7 +12,7 @@ struct irq_action {
 	irq_handler_t handler;
 };
 
-void init_interrupts(void);
+void init_irqs(void);
 void request_irq(irq_num_t irq, irq_handler_t handler, int flags);
 void free_irq(irq_num_t irq);
 void enable_irq(irq_num_t irq);

--- a/include/kernel/irq/bh.h
+++ b/include/kernel/irq/bh.h
@@ -2,11 +2,12 @@
 #ifndef _KERNEL_IRQ_BH_H
 #define _KERNEL_IRQ_BH_H
 
-#define BH_MAX			4
-#define BH_TTY68681		0
-#define BH_TTY			1
-#define BH_SLIP			2
-#define BH_NET			3
+#define BH_MAX			10
+#define BH_TIMER		0
+#define BH_TTY68681		1
+#define BH_TTY			2
+#define BH_SLIP			3
+#define BH_NET			4
 
 typedef void (*bh_handler_t)(void *);
 

--- a/include/kernel/printk.h
+++ b/include/kernel/printk.h
@@ -66,5 +66,15 @@ void printk_dump_bytes(uint8_t *data, uint32_t length);
 #define log_trace(...)
 #endif
 
+#if defined(CONFIG_DEBUG_LEDS)
+#define DBGLED0		0x01
+#define DBGLED1		0x02
+#define DBGLED2		0x04
+#define DBGLED3		0x08
+void debug_leds_set(uint8_t bits);
+void debug_leds_reset(uint8_t bits);
+void debug_leds_toggle(uint8_t bits);
+#endif
+
 #endif
 

--- a/include/kernel/proc/scheduler.h
+++ b/include/kernel/proc/scheduler.h
@@ -3,6 +3,7 @@
 #define _KERNEL_PROC_SCHEDULER_H
 
 #include <sys/types.h>
+#include <kernel/time.h>
 
 struct vnode;
 struct process;
@@ -32,6 +33,7 @@ void restart_current_syscall(void);
 void set_proc_return_value(struct process *proc, int ret);
 void return_to_current_proc(int ret);
 
+void check_reschedule(nanos_t uptime);
 void request_reschedule(void);
 void reschedule_proc_to_now(struct process *proc);
 __attribute__((noreturn)) void begin_multitasking(void);

--- a/include/kernel/proc/timer.h
+++ b/include/kernel/proc/timer.h
@@ -3,6 +3,7 @@
 #define _KERNEL_PROC_TIMER_H
 
 #include <stdint.h>
+#include <kernel/time.h>
 #include <kernel/utils/queue.h>
 
 struct timer;
@@ -11,8 +12,7 @@ typedef int (*timer_callback_t)(struct timer *timer, void *argp);
 
 struct timer {
 	struct queue_node node;
-	unsigned int expires_sec;
-	unsigned int expires_usec;
+	nanos_t expires_time;
 	void *argp;
 	timer_callback_t callback;
 };
@@ -21,6 +21,7 @@ void init_timer_list(void);
 void init_timer(struct timer *timer);
 int add_timer(struct timer *timer, int seconds, int microseconds);
 int remove_timer(struct timer *timer);
-void check_timers(void);
+void check_timers(nanos_t uptime);
+void check_timers_bh(void *_unused);
 
 #endif

--- a/include/kernel/time.h
+++ b/include/kernel/time.h
@@ -2,12 +2,32 @@
 #ifndef _KERNEL_TIME_H
 #define _KERNEL_TIME_H
 
-#include <sys/types.h>
+#include <time.h>
+#include <stdint.h>
+
+#define NANOS_PER_SECOND	1000000000
+
+typedef uint64_t nanos_t;
+typedef uint64_t cycles_t;
+
+/// Represents a monotonic clock used to determine the current time inside the kernel
+///
+/// The `read` function will return a monotonic count of the number of cycles that have occurred
+/// since the system/clock was started.  The count will wrap around to 0 at `max_cycles`, and the
+/// cycle count can be converted to nanoseconds using the `numerator` and `denominator` values
+struct clocksource {
+	char *name;
+	int rating;
+	cycles_t max_cycles;
+	cycles_t (*read)(struct clocksource *clk);
+	nanos_t (*cycles_to_nanos)(struct clocksource *clk, cycles_t cycles);
+};
 
 void init_time(void);
+int register_clock(struct clocksource *clk);
+void update_time(void);
 void set_system_time(time_t t);
 time_t get_system_time(void);
-void get_system_uptime(time_t uptime[2]);
-void adjust_system_time(time_t usec);
+nanos_t get_monotonic_uptime(void);
 
 #endif

--- a/include/kernel/time.h
+++ b/include/kernel/time.h
@@ -13,13 +13,19 @@ typedef uint64_t cycles_t;
 /// Represents a monotonic clock used to determine the current time inside the kernel
 ///
 /// The `read` function will return a monotonic count of the number of cycles that have occurred
-/// since the system/clock was started.  The count will wrap around to 0 at `max_cycles`, and the
-/// cycle count can be converted to nanoseconds using the `numerator` and `denominator` values
+/// since the system/clock was started.  The count will wrap around to 0 at `max_cycles` - 1, and
+/// the cycle count can be converted to nanoseconds using the `cycles_to_nanos` function
 struct clocksource {
+	/// Name of the clock source for logging
 	char *name;
+	/// A quality rating of this clock (higher is better, 100 is average/good)
 	int rating;
+	/// The cycle count at which it will roll over to 0 again (ie. the cycles
+	/// return by `read` will always be between 0 and max_cycles - 1)
 	cycles_t max_cycles;
+	/// Read the current counter value of this clock source (must be monotonic)
 	cycles_t (*read)(struct clocksource *clk);
+	/// Convert a given number of cycles into an equivalent number of nanoseconds
 	nanos_t (*cycles_to_nanos)(struct clocksource *clk, cycles_t cycles);
 };
 

--- a/include/sys/select.h
+++ b/include/sys/select.h
@@ -2,8 +2,8 @@
 #ifndef _SYS_SELECT_H
 #define _SYS_SELECT_H
 
+#include <time.h>
 #include <string.h>
-#include <sys/types.h>
 
 #define _FDS_MAX	128
 

--- a/include/sys/stat.h
+++ b/include/sys/stat.h
@@ -2,6 +2,7 @@
 #ifndef _STAT_H
 #define _STAT_H
 
+#include <time.h>
 #include <sys/types.h>
 
 #define S_IFMT    0170000	/* type of file */

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -4,9 +4,6 @@
 
 #include <stdint.h>
 
-typedef long time_t;
-typedef long clock_t;
-
 typedef int pid_t;
 typedef short device_t;
 

--- a/include/time.h
+++ b/include/time.h
@@ -3,7 +3,9 @@
 #define _TIME_H
 
 #include <stddef.h>
-#include <sys/types.h>
+
+typedef long time_t;
+typedef long clock_t;
 
 struct tm {
 	int tm_sec;			// seconds after the minute [0, 59]

--- a/log.txt
+++ b/log.txt
@@ -5677,3 +5677,103 @@ with short descriptors, initial shift: 4, levels: 1, table entries: 8192, page: 
 - the other bug is that when the clock is registered, so normal conditions, the ntpdate command fails with a bus error for a very
   odd address.  It happens just after the signal handler returns
 
+
+2026-05-02:
+
+- sitting down to these last few bugs, and looking at the [registered] clock one, since it was how I had left it last night.  It
+  seems to be trying to run the start address, but it keeps swapping out the same page, which never resolves.  It looks the same as
+  the error I was getting during init, where it would try to execute 0x40000 without loading the page.  In this case, it's not that
+  it's not causing a page fault when it should, but instead it's causing a page fault that can't seem to resolve.  But in either
+  case, it's right at the start of the execution of that process
+- it didn't seem to be affected by the lack of `update_time` in the irq exit
+- I want to find the root cause here, but I know that "forcing" a context switch is likely to resolve the issue in the long term
+  (like it won't actually boot as-is because time doesn't advance), so maybe I should have a back "clock" that just counts how many
+  times it passes a point.  The clock will be wildly inaccurate, but at least it will boot and run (somewhat)
+
+- I finally looked a bit closer, and saw that the check in irqs.c, where it calls get_page and then checks for error, is actually
+  checking for !error and returning, which is what happens.  It finds a valid page, and then returns because there's nothing wrong.
+  I seem to recall I had a problem with this earlier where it would sometimes throw a bus error when it shouldn't, and left it to
+  return because it would just "work" if I did
+- I can only image that it's not working this time because it's using the wrong mmu table for the process
+
+- that is exactly what's happening.  The mmu table should be 12C500 but is 129200, so something's wrong....
+- I searched for "current_proc =" and found 3 instances in scheduler.c, where I would have expected 2 (the one that sets it to NULL
+  when initiailizing, and one that sets it in `schedule()`).  The third one is in `begin_multitasking()` which definitely is wrong.
+  It will mess up the startup sequence because current_proc will be the same as previous_proc, and then it won't do the extended
+  switch too
+- I would have expected this to fix the problem, but it doesn't seem to, or at least it maybe changes things but causes a different
+  one.  I've tried both calling schedule() directly instead of assigning current_proc, and also removing everything and relying on
+  the `needs_reschedule` variable that invokes a schedule() on `restore_context`
+- I removed a bunch of the log messages that were getting in the way, and now it seems to get further, getting to the signal from
+  ntpdate, and then pid 6 crashes, and it gets into this same unresolving bus error issue.  This is when leaving begin_multitasking
+  empty of scheduling related stuff
+- when I force a schedule before `restore_context` in `begin_multitasking`, it now doesn't crash on pid 6, but still gets into the
+  unresolvable bus error
+- when there's a forced `schedule()` on startup, it fails before the timeout occurs.  When there's no forced `schedule()`, it gets
+  to the timeout, and then fails, so they're different.  They might be related to the condition happening when the clock is
+  [not registered] as well (this is testing with a clock [registered])
+- the problem is causing the infinite bus error is the same, where it's using the wrong table... very strange
+
+- oooh I think this is the problem in exec.c where I'm force-switching the extended context, which might not work correctly.
+  Printing out the current and previous procs and map root tables:
+    ```
+    cur=110F14 prev=110C7A curroot=12D400 prevroot=12C600
+    switched
+    bus error: d w fc=1 addr=49370 ssw=709 mmusr=A04 pid=6 pc=415EC
+    bus error: i r fc=5 addr=40198 ssw=B64D mmusr=202 pid=6 pc=104C1E
+    get page -2: should be 135100 but is 12D400
+    cur=110F14 prev=110F14 curroot=135100 prevroot=135100
+    bus error: i r fc=5 addr=40198 ssw=B64D mmusr=202 pid=6 pc=104C1E
+    get page 0: should be 135100 but is 12D400
+    bus error: i r fc=5 addr=40198 ssw=B64D mmusr=202 pid=6 pc=104C1E
+    get page 0: should be 135100 but is 12D400
+    ```
+- it switches to cur=110F14 with curroot=12D400, but then later says that the table should actually be 135100 instead of 12D400.
+  The process is the same, but the root table has changed, and the most likely reason is that it called exec().
+- I suppose there's also a high risk/likelyhood that the current_proc pointer could be the same if a process exits, and then a new
+  one is forked, and it uses the same slot in the process table.  So checking that the pointers are the same might not actually be
+  accurate to know if the process has changed?  The pid should be different though since we don't recycle them (until it wraps)
+- in light of the fact that it switches a lot of times after starting multitasking, it seems odd that explicitly calling schedule in
+  begin_multitasking vs not causes it to behave differently.  Maybe it's a non-deterministic effect though
+- confirmed that the extended switch in exec.c is the problem by just removing the conditional and always doing the switch
+- I want a better solution here than having the forced switch
+
+- oh actually the clock is registered.  I had that backwards earlier
+
+- Ok, so I moved the arch_extended_switch_context to binaries.c, since the init.c code is the only place that uses the exec calls,
+  and that should be handled by the forced context switch on startup
+- I had thought about making a function in scheduler.c which will invalidate the current_proc/previous_proc as necessary, which I
+  could still do, or make a function in map.c which swaps the process memory_map, and does all the right checks and such, but
+  honestly none of them are a great place for it.  The fact that it could affect usercopy code is also a factor, so I wanted it to
+  go before the exec_initialize_stack_with_args call
+- currently the clock is registered, and pid 6 is crashing on boot, and also time is advancing too fast
+
+- this is so weird.  Sometimes just the ntpdate process crashes, and sometimes after it crashes, it reruns the rc script, the rc
+  shell crashes, ntpdate crashes a second time, and then the pid 3 shell starts and it's more or less fine again...
+- it does not seem to be the case that the root pointer is wrong, or at least I checked in add/remove signal context as well as in
+  that one place in bus error handling
+- it's like the stack page is incorrect, and it's actually a page that has instruction data instead of the actual stack
+
+- it took restoring the adjust_system_time() and bh stuff to get it working again, and not ever calling update time.  I had disabled
+  the timer bh even, so it must not have been the rescheduler time checking code I added.  Was it honestly just the uint64_t
+  multiplication?  Is that code totally messing everything up?  I know it sucks but sheesh
+- yes, it literally is even `diff = cycles * 71111111` in the new update_time.  Without the `cycles *` part, it works fine.  Fuuuck
+- wait, I renamed the two multiplication functions and it didn't do anything.  It probably isn't using them when it's compiling for
+  68030 because it has native 32-bit multiply
+- printing cycles is 0.  Could that cause problems?  Is it even calling the signal handler's terminate too soon?!?  That could
+  corrupt the stack.  Hmm....
+- wait again, the print function is taking a 32-bit number, so maybe it's not converting it correctly?  Is it actually 0?  the clock
+  read function is putting the number into %d0 for the upper and %d1 for the lower, and the update_time function seems to be saving
+  both, but doing different things with them
+- If I explicitly convert the number to a 32-bit number, it has teh right values
+- well... that's interesting... printing out the `diff` value, it's positive but then goes negative.  I guess that's just because
+  it's unsigned and the printk is only printing signed, but it still seems weird...  is something wrong with overflows?
+- well it was supposed to be `diff = diff * 71111111`, so there's that.  it's still not working though
+- is this an interrupts problem?  Interrupts should still be disabled...
+- math was still wrong, and the diff was going up.  I had diff = cycles instead of diff = cycles - current_clock_last_cycles
+- and now it's always increasing by one cycle, never more, and doesn't have the crash during ntpdate, but is it literally just that
+  tho clock going too fast makes it crash?   I still think the problem is that it services the timer expired too early, maybe even
+  before it returns to that process?
+
+- that's exactly it.  The timer occurs too soon.  I changed it to always be 0 seconds, and it now crashes again
+

--- a/log.txt
+++ b/log.txt
@@ -5653,3 +5653,27 @@ with short descriptors, initial shift: 4, levels: 1, table entries: 8192, page: 
   places that might use a signed length/size value, related to issues with the stack being at the upper end of memory or allocating
   all of available user memory
 
+
+2026-05-01:
+
+- I'm trying to change the clock stuff so it's easier to use and more robust to bad clocks, and it seems like there are a lot of
+  ways the updates can stop happening that then cause program crashes, which don't seem to make sense.
+- if the scheduler doesn't run, after the init process is created, then it will try to return to the process and I think be using
+  the kernel memory map instead of the process's, and as a result it tries to execute 0x40000 which is FFFF and causes an exception
+  11 f-line emualtor.  Is it just that the extended switch isn't called, or is it that the current process is NULL but a NULL check
+  isn't performed
+- I'm not sure the state of it at the moment, I think both check timers and request reschedule aren't running, and it starts, the
+  timeout happens right away, and ntpdate crashes immediately but gets to a shell
+
+- the bottom half for the timer wasn't running, and it turned out to be because it wasn't enabled.  Only the tty was enabled, but
+  not the slip or net ones, which explains why networking wasn't working.  I've changed it so registering the bh will automatically
+  enable it, since that's usually what's wanted, and it won't run anyways until returning from an interrutp, so something that
+  really wants to not run it can lock and then register and enable?  Now that I think about it, maybe passing in the enable state
+  might be better, but... maybe I'll leave that for later since it's more overhead that's usually not needed
+
+- so I'm currently left with two bugs, one is where it will continuously bus error on the same address and same pid, pid 4 which is
+  the shell that runs the rc script.  This only happens if clock source isn't registered, which I would expect instead for it to
+  block forever on the signal timer.  I think this is related to scheduling, and maybe means there's a missing reschedule request
+- the other bug is that when the clock is registered, so normal conditions, the ntpdate command fails with a bus error for a very
+  odd address.  It happens just after the signal handler returns
+

--- a/src/commands/ps.c
+++ b/src/commands/ps.c
@@ -1,4 +1,5 @@
 
+#include <time.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/src/kernel/Kconfig
+++ b/src/kernel/Kconfig
@@ -77,6 +77,10 @@ config DEBUG
 	help
 	  This will add in some extra debugging features
 
+config DEBUG_LEDS
+	bool
+	default n
+
 endif
 
 endmenu

--- a/src/kernel/arch/m68k/syscall_entry.S
+++ b/src/kernel/arch/m68k/syscall_entry.S
@@ -32,6 +32,7 @@
 	.global bh_requested
 	.global run_bh_handlers
 	.global mmu_table_create
+	.global update_time
 
 	.equ	SHORT_CONTEXT_SIZE, 24		// The size of the syscall registers on the stack (not including the interrupt return)
 	.equ	FULL_CONTEXT_SIZE, 64		// The size of the saved registers on the stack (not including the interrupt return)
@@ -412,6 +413,8 @@ enter_irq:
 
 	// Pop the irq number off the stack
 	adda.l	#4, %sp
+
+	bsr.w	update_time
 
 	// Jump to the syscall interrupt return
 	bra.w	restore_context

--- a/src/kernel/drivers/tty/mc68681/Kconfig
+++ b/src/kernel/drivers/tty/mc68681/Kconfig
@@ -34,6 +34,7 @@ config TTY_68681_CLOCKSOURCE
 config TTY_68681_GPIO_LEDS
 	bool "Use the MC68681's GPIO outputs to control debug LEDs"
 	depends on TTY_68681
+	select DEBUG_LEDS
 	default y
 	help
 	  If this option is selected, the MC68681's general purpose output pins

--- a/src/kernel/drivers/tty/mc68681/tty_68681.c
+++ b/src/kernel/drivers/tty/mc68681/tty_68681.c
@@ -54,6 +54,10 @@ void tty_68681_reset_leds(uint8_t bits);
 #define TTY_68681_CLOCK_COUNTER_LOAD	0x480	// equals 10 milliseconds
 /// Each time the counter hardware counter expires, the cycle count will be
 /// incremented, and when that cycle count reaches MAX_CYCLES, it will wrap to 0
+/// Since the MC68681 counter cannot be read while running, this value stands in
+/// for a timestamp counter value. The `update_time` function must be called more
+/// often than this time to avoid losing track of cycles, while also being low
+/// enough that we can do 32-bit operations on nanosecond values without overflowing
 #define TTY_68681_CLOCK_MAX_CYCLES	60
 /// The quality rating of this clock (100 is average/good)
 #define TTY_68681_CLOCK_RATING		100

--- a/src/kernel/drivers/tty/mc68681/tty_68681.c
+++ b/src/kernel/drivers/tty/mc68681/tty_68681.c
@@ -188,8 +188,25 @@ struct serial_channel {
 static struct serial_channel channels[2];
 
 #if defined(CONFIG_TTY_68681_CLOCKSOURCE)
+
+#define TTY_68681_CLOCK_OVERFLOW	60
+
 static char handle_timer = 0;
+static uint16_t clock_cycles = 0;
+
+cycles_t tty_68681_read_clock(struct clocksource *clk);
+nanos_t tty_68681_cycles_to_nanos(struct clocksource *clk, cycles_t cycles);
+
+struct clocksource tty_68681_clock = {
+	"mc68681 timer",
+	100,
+	TTY_68681_CLOCK_OVERFLOW,
+	tty_68681_read_clock,
+	tty_68681_cycles_to_nanos,
+};
+
 #endif
+
 #if defined(CONFIG_TTY_68681_GPIO_LEDS)
 static char tick = 0;
 #endif
@@ -272,7 +289,7 @@ static void tty_68681_process_input(void *_unused)
 	#if defined(CONFIG_TTY_68681_CLOCKSOURCE)
 	if (handle_timer) {
 		handle_timer = 0;
-		check_timers();
+		update_time();
 	}
 	#endif
 
@@ -367,6 +384,16 @@ static inline void handle_channel_io(register char isr, register devminor_t mino
 	}
 }
 
+cycles_t tty_68681_read_clock(struct clocksource *clk)
+{
+	return clock_cycles;
+}
+
+nanos_t tty_68681_cycles_to_nanos(struct clocksource *clk, cycles_t cycles)
+{
+	return (nanos_t) (cycles * 71111111);
+}
+
 void handle_serial_irq(void)
 {
 	#if defined(CONFIG_TTY_68681_GPIO_LEDS)
@@ -396,8 +423,10 @@ void handle_serial_irq(void)
 		#endif
 
 		#if defined(CONFIG_TTY_68681_CLOCKSOURCE)
-		adjust_system_time(71111);
-		request_reschedule();
+		clock_cycles += 1;
+		if (clock_cycles >= TTY_68681_CLOCK_OVERFLOW) {
+			clock_cycles = 0;
+		}
 
 		handle_timer = 1;
 		request_bh_run(BH_TTY68681);
@@ -521,6 +550,7 @@ void tty_68681_normal_mode(void)
 	// Configure timer
 	*CTUR_WR_ADDR = 0x20;
 	*CTLR_WR_ADDR = 0x00;
+	clock_cycles = 0;
 	#endif
 
 	// Enable interrupts
@@ -586,6 +616,10 @@ int tty_68681_init(void)
 	int error;
 
 	tty_68681_normal_mode();
+
+	#if defined(CONFIG_TTY_68681_CLOCKSOURCE)
+	register_clock(&tty_68681_clock);
+	#endif
 
 	error = register_driver(DEVMAJOR_TTY68681, &tty_68681_driver);
 	if (error < 0)

--- a/src/kernel/drivers/tty/mc68681/tty_68681.c
+++ b/src/kernel/drivers/tty/mc68681/tty_68681.c
@@ -213,8 +213,8 @@ static struct serial_channel channels[2];
 
 #if defined(CONFIG_TTY_68681_CLOCKSOURCE)
 
-// NOTE this is force to a floating point number for the calculation and then back to a 32-bit int,
-// which should be able to hold this value comfortable. Without the float conversion, the compiler
+// NOTE this is forced to a floating point number for the calculation and then back to a 32-bit int,
+// which should be able to hold this value comfortably. Without the float conversion, the compiler
 // will not generate an accurate number. No floating point operations should be performed at runtime
 #define TTY_68681_CYCLES_TO_NANOS		(uint32_t) ((double) TTY_68681_CLOCK_COUNTER_LOAD * 16 * 2 * NANOS_PER_SECOND / 3686400)
 

--- a/src/kernel/drivers/tty/mc68681/tty_68681.c
+++ b/src/kernel/drivers/tty/mc68681/tty_68681.c
@@ -45,8 +45,6 @@ struct driver tty_68681_driver = {
 };
 
 void tty_68681_tx_safe_mode(void);
-void tty_68681_set_leds(uint8_t bits);
-void tty_68681_reset_leds(uint8_t bits);
 
 #if defined(CONFIG_TTY_68681_CLOCKSOURCE)
 
@@ -222,12 +220,6 @@ static struct serial_channel channels[2];
 
 static char handle_timer = 0;
 static uint16_t clock_cycles = 0;
-
-#endif
-
-#if defined(CONFIG_TTY_68681_GPIO_LEDS)
-
-static char tick = 0;
 
 #endif
 
@@ -419,18 +411,8 @@ void handle_serial_irq(void)
 
 	if (isr & ISR_TIMER_CHANGE) {
 		// Clear the interrupt bit by reading the stop address
-		volatile register char reset = *STOP_RD_ADDR;
+		volatile register uint8_t reset = *STOP_RD_ADDR;
 		reset;	// make the compiler happy
-
-		#if defined(CONFIG_TTY_68681_GPIO_LEDS)
-		if (tick) {
-			tick = 0;
-			*OUT_SET_ADDR = 0x80;
-		} else {
-			tick = 1;
-			*OUT_RESET_ADDR = 0x80;
-		}
-		#endif
 
 		#if defined(CONFIG_TTY_68681_CLOCKSOURCE)
 		clock_cycles += 1;
@@ -443,11 +425,12 @@ void handle_serial_irq(void)
 		#endif
 	}
 
-	/*
 	if (isr & ISR_INPUT_CHANGE) {
 		// Reading from the IPCR register will clear the interrupt
-		uint8_t status = *IPCR_RD_ADDR;
+		volatile register uint8_t status = *IPCR_RD_ADDR;
+		status;	// make the compiler happy
 
+		/*
 		tty_68681_tx_safe_mode();
 		asm(
 		"move.l	#0, %a0\n"
@@ -476,27 +459,12 @@ void handle_serial_irq(void)
 			);
 		}
 		//TRACE_ON();
-
+		*/
 	}
-	*/
 
 	#if defined(CONFIG_TTY_68681_GPIO_LEDS)
 	// TODO this is for debugging to tell me when the handler exits
 	*OUT_RESET_ADDR = 0x08;
-	#endif
-}
-
-void tty_68681_set_leds(uint8_t bits)
-{
-	#if defined(CONFIG_TTY_68681_GPIO_LEDS)
-	*OUT_SET_ADDR = (bits << 4);
-	#endif
-}
-
-void tty_68681_reset_leds(uint8_t bits)
-{
-	#if defined(CONFIG_TTY_68681_GPIO_LEDS)
-	*OUT_RESET_ADDR = (bits << 4);
 	#endif
 }
 
@@ -744,8 +712,8 @@ int tty_68681_ioctl(devminor_t minor, unsigned int request, struct iovec_iter *i
 			int leds;
 			memcpy_out_of_iter(iter, &leds, sizeof(int));
 			leds &= 0x03;
-			tty_68681_reset_leds(~leds);
-			tty_68681_set_leds(leds);
+			debug_leds_reset(~leds);
+			debug_leds_set(leds);
 			return 0;
 		}
 		#endif
@@ -790,4 +758,37 @@ int console_putchar_buffered(int ch)
 {
 	return tty_68681_putchar_buffered(&channels[CH_A], ch);
 }
+
+////// Debug LED Interface //////
+
+#if defined(CONFIG_TTY_68681_GPIO_LEDS)
+uint8_t led_state;
+
+void debug_leds_set(uint8_t bits)
+{
+	led_state |= bits;
+	*OUT_SET_ADDR = (bits << 4);
+}
+
+void debug_leds_reset(uint8_t bits)
+{
+	led_state &= ~bits;
+	*OUT_RESET_ADDR = (bits << 4);
+}
+
+void debug_leds_toggle(uint8_t bits)
+{
+	uint8_t set = ~led_state & bits;
+	uint8_t reset = led_state & bits;
+
+	if (set) {
+		debug_leds_set(set);
+	}
+
+	if (reset) {
+		debug_leds_reset(reset);
+	}
+}
+#endif
+
 

--- a/src/kernel/drivers/tty/mc68681/tty_68681.c
+++ b/src/kernel/drivers/tty/mc68681/tty_68681.c
@@ -48,39 +48,61 @@ void tty_68681_tx_safe_mode(void);
 void tty_68681_set_leds(uint8_t bits);
 void tty_68681_reset_leds(uint8_t bits);
 
+#if defined(CONFIG_TTY_68681_CLOCKSOURCE)
+
+/// The value loaded into the 16-bit counter register
+#define TTY_68681_CLOCK_COUNTER_LOAD	0x480	// equals 10 milliseconds
+/// Each time the counter hardware counter expires, the cycle count will be
+/// incremented, and when that cycle count reaches MAX_CYCLES, it will wrap to 0
+#define TTY_68681_CLOCK_MAX_CYCLES	60
+/// The quality rating of this clock (100 is average/good)
+#define TTY_68681_CLOCK_RATING		100
+
+cycles_t tty_68681_read_clock(struct clocksource *clk);
+nanos_t tty_68681_cycles_to_nanos(struct clocksource *clk, cycles_t cycles);
+
+struct clocksource tty_68681_clock = {
+	"mc68681 timer",
+	TTY_68681_CLOCK_RATING,
+	TTY_68681_CLOCK_MAX_CYCLES,
+	tty_68681_read_clock,
+	tty_68681_cycles_to_nanos,
+};
+
+#endif
 
 // MC68681 Register Addresses
 #define DUART_REG_BASE 	CONFIG_TTY_68681_BASE 
-#define MR1A_MR2A_ADDR	((volatile uint8_t *) DUART_REG_BASE + 0x00)
-#define SRA_RD_ADDR		((volatile uint8_t *) DUART_REG_BASE + 0x02)
-#define CSRA_WR_ADDR	((volatile uint8_t *) DUART_REG_BASE + 0x02)
-#define CRA_WR_ADDR		((volatile uint8_t *) DUART_REG_BASE + 0x04)
-#define TBA_WR_ADDR		((volatile uint8_t *) DUART_REG_BASE + 0x06)
-#define RBA_RD_ADDR		((volatile uint8_t *) DUART_REG_BASE + 0x06)
+#define MR1A_MR2A_ADDR			((volatile uint8_t *) DUART_REG_BASE + 0x00)
+#define SRA_RD_ADDR			((volatile uint8_t *) DUART_REG_BASE + 0x02)
+#define CSRA_WR_ADDR			((volatile uint8_t *) DUART_REG_BASE + 0x02)
+#define CRA_WR_ADDR			((volatile uint8_t *) DUART_REG_BASE + 0x04)
+#define TBA_WR_ADDR			((volatile uint8_t *) DUART_REG_BASE + 0x06)
+#define RBA_RD_ADDR			((volatile uint8_t *) DUART_REG_BASE + 0x06)
 
-#define MR1B_MR2B_ADDR	((volatile uint8_t *) DUART_REG_BASE + 0x10)
-#define SRB_RD_ADDR		((volatile uint8_t *) DUART_REG_BASE + 0x12)
-#define CSRB_WR_ADDR	((volatile uint8_t *) DUART_REG_BASE + 0x12)
-#define CRB_WR_ADDR		((volatile uint8_t *) DUART_REG_BASE + 0x14)
-#define TBB_WR_ADDR		((volatile uint8_t *) DUART_REG_BASE + 0x16)
-#define RBB_RD_ADDR		((volatile uint8_t *) DUART_REG_BASE + 0x16)
+#define MR1B_MR2B_ADDR			((volatile uint8_t *) DUART_REG_BASE + 0x10)
+#define SRB_RD_ADDR			((volatile uint8_t *) DUART_REG_BASE + 0x12)
+#define CSRB_WR_ADDR			((volatile uint8_t *) DUART_REG_BASE + 0x12)
+#define CRB_WR_ADDR			((volatile uint8_t *) DUART_REG_BASE + 0x14)
+#define TBB_WR_ADDR			((volatile uint8_t *) DUART_REG_BASE + 0x16)
+#define RBB_RD_ADDR			((volatile uint8_t *) DUART_REG_BASE + 0x16)
 
-#define ACR_WR_ADDR		((volatile uint8_t *) DUART_REG_BASE + 0x08)
+#define ACR_WR_ADDR			((volatile uint8_t *) DUART_REG_BASE + 0x08)
 
-#define CTUR_WR_ADDR	((volatile uint8_t *) DUART_REG_BASE + 0x0C)
-#define CTLR_WR_ADDR	((volatile uint8_t *) DUART_REG_BASE + 0x0E)
-#define START_RD_ADDR	((volatile uint8_t *) DUART_REG_BASE + 0x1C)
-#define STOP_RD_ADDR	((volatile uint8_t *) DUART_REG_BASE + 0x1E)
+#define CTUR_WR_ADDR			((volatile uint8_t *) DUART_REG_BASE + 0x0C)
+#define CTLR_WR_ADDR			((volatile uint8_t *) DUART_REG_BASE + 0x0E)
+#define START_RD_ADDR			((volatile uint8_t *) DUART_REG_BASE + 0x1C)
+#define STOP_RD_ADDR			((volatile uint8_t *) DUART_REG_BASE + 0x1E)
 
-#define IPCR_RD_ADDR	((volatile uint8_t *) DUART_REG_BASE + 0x08)
-#define OPCR_WR_ADDR	((volatile uint8_t *) DUART_REG_BASE + 0x1A)
-#define INPUT_RD_ADDR	((volatile uint8_t *) DUART_REG_BASE + 0x1A)
-#define OUT_SET_ADDR	((volatile uint8_t *) DUART_REG_BASE + 0x1C)
-#define OUT_RESET_ADDR	((volatile uint8_t *) DUART_REG_BASE + 0x1E)
+#define IPCR_RD_ADDR			((volatile uint8_t *) DUART_REG_BASE + 0x08)
+#define OPCR_WR_ADDR			((volatile uint8_t *) DUART_REG_BASE + 0x1A)
+#define INPUT_RD_ADDR			((volatile uint8_t *) DUART_REG_BASE + 0x1A)
+#define OUT_SET_ADDR			((volatile uint8_t *) DUART_REG_BASE + 0x1C)
+#define OUT_RESET_ADDR			((volatile uint8_t *) DUART_REG_BASE + 0x1E)
 
-#define ISR_RD_ADDR		((volatile uint8_t *) DUART_REG_BASE + 0x0A)
-#define IMR_WR_ADDR		((volatile uint8_t *) DUART_REG_BASE + 0x0A)
-#define IVR_WR_ADDR		((volatile uint8_t *) DUART_REG_BASE + 0x18)
+#define ISR_RD_ADDR			((volatile uint8_t *) DUART_REG_BASE + 0x0A)
+#define IMR_WR_ADDR			((volatile uint8_t *) DUART_REG_BASE + 0x0A)
+#define IVR_WR_ADDR			((volatile uint8_t *) DUART_REG_BASE + 0x18)
 
 
 // MC68681 Command Numbers
@@ -189,26 +211,20 @@ static struct serial_channel channels[2];
 
 #if defined(CONFIG_TTY_68681_CLOCKSOURCE)
 
-#define TTY_68681_CLOCK_OVERFLOW	60
+// NOTE this is force to a floating point number for the calculation and then back to a 32-bit int,
+// which should be able to hold this value comfortable. Without the float conversion, the compiler
+// will not generate an accurate number. No floating point operations should be performed at runtime
+#define TTY_68681_CYCLES_TO_NANOS		(uint32_t) ((double) TTY_68681_CLOCK_COUNTER_LOAD * 16 * 2 * NANOS_PER_SECOND / 3686400)
 
 static char handle_timer = 0;
 static uint16_t clock_cycles = 0;
 
-cycles_t tty_68681_read_clock(struct clocksource *clk);
-nanos_t tty_68681_cycles_to_nanos(struct clocksource *clk, cycles_t cycles);
-
-struct clocksource tty_68681_clock = {
-	"mc68681 timer",
-	100,
-	TTY_68681_CLOCK_OVERFLOW,
-	tty_68681_read_clock,
-	tty_68681_cycles_to_nanos,
-};
-
 #endif
 
 #if defined(CONFIG_TTY_68681_GPIO_LEDS)
+
 static char tick = 0;
+
 #endif
 
 static inline void config_serial_channel(struct serial_channel *channel)
@@ -384,16 +400,6 @@ static inline void handle_channel_io(register char isr, register devminor_t mino
 	}
 }
 
-cycles_t tty_68681_read_clock(struct clocksource *clk)
-{
-	return clock_cycles;
-}
-
-nanos_t tty_68681_cycles_to_nanos(struct clocksource *clk, cycles_t cycles)
-{
-	return (nanos_t) (cycles * 71111111);
-}
-
 void handle_serial_irq(void)
 {
 	#if defined(CONFIG_TTY_68681_GPIO_LEDS)
@@ -424,7 +430,7 @@ void handle_serial_irq(void)
 
 		#if defined(CONFIG_TTY_68681_CLOCKSOURCE)
 		clock_cycles += 1;
-		if (clock_cycles >= TTY_68681_CLOCK_OVERFLOW) {
+		if (clock_cycles >= TTY_68681_CLOCK_MAX_CYCLES) {
 			clock_cycles = 0;
 		}
 
@@ -548,8 +554,8 @@ void tty_68681_normal_mode(void)
 
 	#if defined(CONFIG_TTY_68681_CLOCKSOURCE)
 	// Configure timer
-	*CTUR_WR_ADDR = 0x20;
-	*CTLR_WR_ADDR = 0x00;
+	*CTUR_WR_ADDR = TTY_68681_CLOCK_COUNTER_LOAD >> 8;
+	*CTLR_WR_ADDR = (uint8_t) TTY_68681_CLOCK_COUNTER_LOAD;
 	clock_cycles = 0;
 	#endif
 
@@ -596,8 +602,25 @@ void tty_68681_preinit(void)
 	tty_68681_tx_safe_mode();
 }
 
+////// Kernel Clock Driver Interface //////
 
-////// Kernel Driver Interface //////
+#if defined(CONFIG_TTY_68681_CLOCKSOURCE)
+
+cycles_t tty_68681_read_clock(struct clocksource *clk)
+{
+	return clock_cycles;
+}
+
+nanos_t tty_68681_cycles_to_nanos(struct clocksource *clk, cycles_t cycles)
+{
+	// NOTE the TTY_68681_CLOCK_MAX_CYCLES value is selected to never overflow a 32-bit number
+	// so we can convert the cycles to 32-bit and speed this calculation up
+	return (nanos_t) ((uint32_t) cycles * TTY_68681_CYCLES_TO_NANOS);
+}
+
+#endif
+
+////// Kernel Character Driver Interface //////
 
 static inline struct serial_channel *from_minor_dev(device_t minor)
 {

--- a/src/kernel/irq/action.c
+++ b/src/kernel/irq/action.c
@@ -25,10 +25,8 @@ void handle_trace(void);
 
 static struct irq_action action_table[INTERRUPT_MAX];
 
-void init_interrupts(void)
+void init_irqs(void)
 {
-	init_bh();
-
 	extern void enter_handle_exception(void);
 	for (short i = 0; i < INTERRUPT_MAX; i++) {
 		action_table[i].irq = 0;

--- a/src/kernel/irq/bh.c
+++ b/src/kernel/irq/bh.c
@@ -23,21 +23,22 @@ void register_bh(int bhnum, bh_handler_t fn, void *data)
 {
 	bh_handlers[bhnum].fn = fn;
 	bh_handlers[bhnum].data = data;
+	bh_enabled |= (1 << bhnum);
 }
 
 void enable_bh(int bhnum)
 {
-	bh_enabled |= (0x0001 << bhnum);
+	bh_enabled |= (1 << bhnum);
 }
 
 void disable_bh(int bhnum)
 {
-	bh_enabled &= ~(0x0001 << bhnum);
+	bh_enabled &= ~(1 << bhnum);
 }
 
 void request_bh_run(int bhnum)
 {
-	bh_requested |= (0x0001 << bhnum);
+	bh_requested |= (1 << bhnum);
 }
 
 void run_bh_handlers(void)

--- a/src/kernel/main.c
+++ b/src/kernel/main.c
@@ -14,6 +14,7 @@
 #include <kernel/printk.h>
 #include <kernel/syscall.h>
 #include <kernel/drivers.h>
+#include <kernel/irq/bh.h>
 #include <kernel/irq/action.h>
 #include <kernel/fs/vfs.h>
 #include <kernel/mm/pages.h>
@@ -153,9 +154,10 @@ int main(void)
 	if (error < 0)
 		goto fail;
 
+	init_bh();
+	init_irqs();
 	init_time();
 	init_timer_list();
-	init_interrupts();
 	init_proc();
 	init_scheduler();
 

--- a/src/kernel/mm/map.c
+++ b/src/kernel/mm/map.c
@@ -154,7 +154,6 @@ int memory_map_load_page_at(struct memory_map *map, virtual_address_t vaddr, uin
 
 	if (segment->ops && segment->ops->load_page_at) {
 		page_address = rounddown(vaddr, PAGE_SIZE);
-		// TODO should you add support for large pages?
 		error = mmu_table_get_page(map->root_table, page_address, &result);
 		if (!error) {
 			if (write_error && (segment->flags & SEG_WRITE)) {

--- a/src/kernel/proc/Kconfig
+++ b/src/kernel/proc/Kconfig
@@ -17,7 +17,7 @@ config KERNEL_STACK_SIZE
 	  process that's executed, to be used exclusively by the kernel.
 	  It is expressed in bytes, and must be aligned to CONFIG_PAGE_SIZE
 
-config RESCHEDULE_PERIOD
+config CONFIG_RESCHEDULE_PERIOD_MS
 	int "reschedule period in milliseconds"
 	default 100
 	help

--- a/src/kernel/proc/Kconfig
+++ b/src/kernel/proc/Kconfig
@@ -17,4 +17,11 @@ config KERNEL_STACK_SIZE
 	  process that's executed, to be used exclusively by the kernel.
 	  It is expressed in bytes, and must be aligned to CONFIG_PAGE_SIZE
 
+config RESCHEDULE_PERIOD
+	int "reschedule period in milliseconds"
+	default 100
+	help
+	  This is time in milliseconds that a process will be run for before
+	  a reschedule is requested.
+
 endmenu

--- a/src/kernel/proc/binaries.c
+++ b/src/kernel/proc/binaries.c
@@ -10,6 +10,7 @@
 #include <kernel/fs/vfs.h>
 #include <kernel/mm/map.h>
 #include <kernel/proc/exec.h>
+#include <kernel/arch/context.h>
 #include <kernel/proc/process.h>
 #include <kernel/utils/math.h>
 
@@ -71,6 +72,9 @@ int load_binary(const char *path, struct process *proc, struct string_array *arg
 
 	// Swap the existing memory map for the newly created one
 	proc->map = map;
+	if (!current_proc || current_proc == proc) {
+		arch_extended_switch_context(NULL, proc);
+	}
 
 	// Initialize the stack pointer first, so that the check in memory_map_move_sbrk will pass
 	error = exec_initialize_stack_with_args(proc, map->stack_end, entry, argv, envp);

--- a/src/kernel/proc/exec.c
+++ b/src/kernel/proc/exec.c
@@ -3,7 +3,6 @@
 #include <string.h>
 #include <sys/param.h>
 
-#include <asm/context.h>
 #include <asm/addresses.h>
 
 #include <kernel/mm/map.h>
@@ -71,10 +70,6 @@ int exec_initialize_stack_with_args(struct process *proc, virtual_address_t stac
 	result = iovec_iter_seek(&iter, 0, SEEK_END);
 	if (result < 0) {
 		return result;
-	}
-
-	if (current_proc != proc) {
-		arch_extended_switch_context(NULL, proc);
 	}
 
 	result = copy_exec_args(proc->map, stack_pointer - buffered_size, &iter, argv, envp);

--- a/src/kernel/proc/init.c
+++ b/src/kernel/proc/init.c
@@ -51,9 +51,6 @@ struct process *create_init_task(void)
 	if (!proc->fd_table)
 		goto fail;
 
-	// Set the current proc, or some of the functions that will be called won't do the right thing
-	current_proc = proc;
-
 	#if defined(CONFIG_SHELL_IN_KERNEL)
 
 	const char *envp[1] = { NULL };

--- a/src/kernel/proc/scheduler.c
+++ b/src/kernel/proc/scheduler.c
@@ -245,7 +245,6 @@ void return_to_current_proc(int ret)
 void check_reschedule(nanos_t uptime)
 {
 	if (uptime > next_reschedule_time) {
-		next_reschedule_time = uptime + CONFIG_RESCHEDULE_PERIOD;
 		need_reschedule = 1;
 	}
 }
@@ -290,12 +289,16 @@ void schedule(void)
 
 	// Switch the current process
 	current_proc = next;
-	next_reschedule_time = get_monotonic_uptime() + CONFIG_RESCHEDULE_PERIOD;
+	next_reschedule_time = get_monotonic_uptime() + CONFIG_RESCHEDULE_PERIOD_MS * 1000 * 1000;
 
 	if (current_proc != previous_proc) {
 		arch_extended_switch_context(previous_proc, current_proc);
 	}
 	UNLOCK(saved_status);
+
+	#if defined(CONFIG_DEBUG_LEDS)
+	debug_leds_toggle(DBGLED3);
+	#endif
 
 	// Restart the new process's the last system call
 	if (current_proc->state == PS_RESUMING) {

--- a/src/kernel/proc/scheduler.c
+++ b/src/kernel/proc/scheduler.c
@@ -245,6 +245,7 @@ void return_to_current_proc(int ret)
 void check_reschedule(nanos_t uptime)
 {
 	if (uptime > next_reschedule_time) {
+		next_reschedule_time = uptime + CONFIG_RESCHEDULE_PERIOD_MS * 1000 * 1000;
 		need_reschedule = 1;
 	}
 }

--- a/src/kernel/proc/scheduler.c
+++ b/src/kernel/proc/scheduler.c
@@ -306,13 +306,7 @@ void schedule(void)
 
 __attribute__((noreturn)) void begin_multitasking(void)
 {
-	current_proc = (struct process *) run_queue.head;
-
-	//panic("Panicking for good measure\n");
-
-	// Force an address error for testing
-	//volatile uint16_t *data = (uint16_t *) 0x100001;
-	//volatile uint16_t value = *data;
+	need_reschedule = 1;
 
 	// Start Multitasking
 	GOTO_LABEL("restore_context");

--- a/src/kernel/proc/scheduler.c
+++ b/src/kernel/proc/scheduler.c
@@ -4,6 +4,7 @@
 
 #include <asm/irqs.h>
 #include <kernel/api.h>
+#include <kernel/time.h>
 #include <kernel/printk.h>
 #include <kernel/utils/queue.h>
 #include <kernel/arch/context.h>
@@ -17,6 +18,7 @@ void *kernel_stack;
 void *kernel_stack_backup;
 int need_reschedule;
 int kernel_reentries;
+nanos_t next_reschedule_time;
 struct process *idle_proc;
 struct process *current_proc;
 struct process *previous_proc;
@@ -27,7 +29,8 @@ static struct queue blocked_queue;
 
 void init_scheduler(void)
 {
-	need_reschedule = 0;
+	need_reschedule = 1;
+	next_reschedule_time = 0;
 	kernel_reentries = 1;
 	current_proc = NULL;
 	previous_proc = NULL;
@@ -239,6 +242,14 @@ void return_to_current_proc(int ret)
 }
 
 
+void check_reschedule(nanos_t uptime)
+{
+	if (uptime > next_reschedule_time) {
+		next_reschedule_time = uptime + CONFIG_RESCHEDULE_PERIOD;
+		need_reschedule = 1;
+	}
+}
+
 void request_reschedule(void)
 {
 	need_reschedule = 1;
@@ -279,6 +290,7 @@ void schedule(void)
 
 	// Switch the current process
 	current_proc = next;
+	next_reschedule_time = get_monotonic_uptime() + CONFIG_RESCHEDULE_PERIOD;
 
 	if (current_proc != previous_proc) {
 		arch_extended_switch_context(previous_proc, current_proc);

--- a/src/kernel/proc/timer.c
+++ b/src/kernel/proc/timer.c
@@ -1,7 +1,9 @@
 
 #include <kernel/time.h>
+#include <kernel/irq/bh.h>
 #include <kernel/proc/timer.h>
 #include <kernel/proc/signal.h>
+#include <kernel/proc/scheduler.h>
 #include <kernel/utils/queue.h>
 
 
@@ -10,50 +12,55 @@ static struct queue timer_list;
 void init_timer_list(void)
 {
 	_queue_init(&timer_list);
+	register_bh(BH_TIMER, check_timers_bh, NULL);
 }
 
 void init_timer(struct timer *timer)
 {
 	_queue_node_init(&timer->node);
-	timer->expires_sec = 0;
-	timer->expires_usec = 0;
+	timer->expires_time = 0;
 }
 
 int add_timer(struct timer *timer, int seconds, int microseconds)
 {
-	time_t uptime[2];
+	nanos_t uptime;
 
-	if (timer->expires_sec || timer->expires_usec)
+	if (timer->expires_time)
 		_queue_remove(&timer_list, &timer->node);
-	get_system_uptime(uptime);
-	timer->expires_sec = uptime[0] + seconds;
-	timer->expires_usec = uptime[1] + microseconds;
+	uptime = get_monotonic_uptime();
+	timer->expires_time = uptime + (seconds * NANOS_PER_SECOND) + (microseconds * 1000);
 	_queue_insert(&timer_list, &timer->node);
 	return 0;
 }
 
 int remove_timer(struct timer *timer)
 {
-	if (!timer->expires_sec && !timer->expires_usec)
+	if (!timer->expires_time)
 		return -1;
 	_queue_remove(&timer_list, &timer->node);
-	timer->expires_sec = 0;
-	timer->expires_usec = 0;
+	timer->expires_time = 0;
 	return 0;
 }
 
-void check_timers(void)
+void check_timers(nanos_t uptime)
 {
-	time_t uptime[2];
 	struct timer *next = NULL;
 
-	get_system_uptime(uptime);
 	for (struct timer *cur = (struct timer *) _queue_head(&timer_list); cur; cur = next) {
 		next = (struct timer *) _queue_next(&cur->node);
-		if (uptime[0] > cur->expires_sec && uptime[1] > cur->expires_usec) {
+		if (uptime > cur->expires_time) {
 			remove_timer(cur);
 			cur->callback(cur, cur->argp);
 		}
 	}
+}
+
+void check_timers_bh(void *_unused)
+{
+	nanos_t uptime;
+
+	uptime = get_monotonic_uptime();
+	check_timers(uptime);
+	check_reschedule(uptime);
 }
 

--- a/src/kernel/syscall.c
+++ b/src/kernel/syscall.c
@@ -38,7 +38,7 @@ extern struct process *current_proc;
 extern struct syscall_record *current_syscall;
 
 
-#if defined(CONFIG_TTY_68681)
+#if defined(CONFIG_TTY_68681) && defined(CONFIG_TTY_68681_GPIO_LEDS)
 void tty_68681_set_leds(uint8_t bits);
 void tty_68681_reset_leds(uint8_t bits);
 #endif
@@ -50,7 +50,7 @@ void tty_68681_reset_leds(uint8_t bits);
 /// the syscall info that is about to be executed
 void syscall_entry(void)
 {
-	#if defined(CONFIG_TTY_68681)
+	#if defined(CONFIG_TTY_68681) && defined(CONFIG_TTY_68681_GPIO_LEDS)
 	tty_68681_set_leds(0x01);
 	#endif
 }
@@ -62,7 +62,7 @@ void syscall_entry(void)
 /// debugging info, as a counterpart to `syscall_entry()`
 void syscall_exit(void)
 {
-	#if defined(CONFIG_TTY_68681)
+	#if defined(CONFIG_TTY_68681) && defined(CONFIG_TTY_68681_GPIO_LEDS)
 	tty_68681_reset_leds(0x01);
 	#endif
 }

--- a/src/kernel/syscall.c
+++ b/src/kernel/syscall.c
@@ -38,11 +38,6 @@ extern struct process *current_proc;
 extern struct syscall_record *current_syscall;
 
 
-#if defined(CONFIG_TTY_68681) && defined(CONFIG_TTY_68681_GPIO_LEDS)
-void tty_68681_set_leds(uint8_t bits);
-void tty_68681_reset_leds(uint8_t bits);
-#endif
-
 /// Called on entry to any system call
 ///
 /// Any code that should run before a syscall is processed should go here, such
@@ -50,8 +45,8 @@ void tty_68681_reset_leds(uint8_t bits);
 /// the syscall info that is about to be executed
 void syscall_entry(void)
 {
-	#if defined(CONFIG_TTY_68681) && defined(CONFIG_TTY_68681_GPIO_LEDS)
-	tty_68681_set_leds(0x01);
+	#if defined(CONFIG_DEBUG_LEDS)
+	debug_leds_toggle(DBGLED0);
 	#endif
 }
 
@@ -62,8 +57,8 @@ void syscall_entry(void)
 /// debugging info, as a counterpart to `syscall_entry()`
 void syscall_exit(void)
 {
-	#if defined(CONFIG_TTY_68681) && defined(CONFIG_TTY_68681_GPIO_LEDS)
-	tty_68681_reset_leds(0x01);
+	#if defined(CONFIG_DEBUG_LEDS)
+	debug_leds_toggle(DBGLED0);
 	#endif
 }
 

--- a/src/kernel/time.c
+++ b/src/kernel/time.c
@@ -1,17 +1,72 @@
 
-#include <sys/types.h>
+#include <time.h>
+#include <kernel/time.h>
+#include <kernel/printk.h>
+#include <kernel/irq/bh.h>
 
 
 static time_t system_seconds;
-static time_t system_uptime;
-static time_t system_useconds;
+static time_t system_subseconds_nanos;
+static cycles_t current_clock_last_cycle;
+static nanos_t monotonic_uptime_nanos;
+
+struct clocksource *current_clock;
 
 void init_time(void)
 {
-	// TODO no real time clock atm
 	system_seconds = 0;
-	system_uptime = 0;
-	system_useconds = 0;
+	system_subseconds_nanos = 0;
+	current_clock_last_cycle = 0;
+	monotonic_uptime_nanos = 0;
+	current_clock = NULL;
+}
+
+int register_clock(struct clocksource *clock)
+{
+	if (!current_clock || clock->rating > current_clock->rating) {
+		log_debug("%s: switching to clock %s\n", __func__, clock->name);
+		current_clock = clock;
+		return 1;
+	} else {
+		log_info("%s: the rating of clock %s is not better than %s\n", __func__, clock->name, current_clock->name);
+		return 0;
+	}
+}
+
+void update_time(void)
+{
+	nanos_t diff;
+	cycles_t cycles;
+
+	request_bh_run(BH_TIMER);
+
+	if (!current_clock)
+		return;
+
+	cycles = current_clock->read(current_clock);
+
+	// Check if the clock has overflowed
+	if (cycles == current_clock_last_cycle) {
+		return;
+	} else if (cycles < current_clock_last_cycle) {
+		diff = (current_clock->max_cycles - current_clock_last_cycle) + cycles;
+	} else {
+		diff = cycles;
+	}
+	current_clock_last_cycle = cycles;
+
+	// Convert to nanoseconds
+	diff = current_clock->cycles_to_nanos(current_clock, diff);
+
+	// Update monotonic uptime
+	monotonic_uptime_nanos += diff;
+
+	// Update epoch time
+	system_subseconds_nanos += diff;
+	while (system_subseconds_nanos >= NANOS_PER_SECOND) {
+		system_subseconds_nanos -= NANOS_PER_SECOND;
+		system_seconds += 1;
+	}
 }
 
 void set_system_time(time_t t)
@@ -24,19 +79,8 @@ time_t get_system_time(void)
 	return system_seconds;
 }
 
-void get_system_uptime(time_t uptime[2])
+nanos_t get_monotonic_uptime(void)
 {
-	uptime[0] = system_uptime;
-	uptime[1] = system_useconds;
-}
-
-void adjust_system_time(time_t usec)
-{
-	system_useconds += usec;
-	while (system_useconds >= 1000000) {
-		system_useconds -= 1000000;
-		system_seconds += 1;
-		system_uptime += 1;
-	}
+	return monotonic_uptime_nanos;
 }
 

--- a/src/kernel/time.c
+++ b/src/kernel/time.c
@@ -10,6 +10,7 @@ static time_t system_seconds;
 static time_t system_subseconds_nanos;
 static cycles_t current_clock_last_cycle;
 static nanos_t monotonic_uptime_nanos;
+static char clock_warning_given = 0;
 
 struct clocksource *current_clock;
 
@@ -20,6 +21,7 @@ void init_time(void)
 	current_clock_last_cycle = 0;
 	monotonic_uptime_nanos = 0;
 	current_clock = NULL;
+	clock_warning_given = 0;
 }
 
 int register_clock(struct clocksource *clock)
@@ -60,6 +62,10 @@ void update_time(void)
 		// Convert to nanoseconds
 		diff = current_clock->cycles_to_nanos(current_clock, diff);
 	} else {
+		if (!clock_warning_given) {
+			clock_warning_given = 1;
+			log_error("clock: no clock was set, defaulting to rough counting\n");
+		}
 		// If there's no current clock, just increase the clock by a bit
 		// This function should be called periodically whenever an irq occurs, which could
 		// be any length of time.  A fixed amount is better than nothing

--- a/src/kernel/time.c
+++ b/src/kernel/time.c
@@ -1,5 +1,6 @@
 
 #include <time.h>
+#include <asm/irqs.h>
 #include <kernel/time.h>
 #include <kernel/printk.h>
 #include <kernel/irq/bh.h>
@@ -24,11 +25,11 @@ void init_time(void)
 int register_clock(struct clocksource *clock)
 {
 	if (!current_clock || clock->rating > current_clock->rating) {
-		log_debug("%s: switching to clock %s\n", __func__, clock->name);
+		log_debug("clock: switching to clock %s\n", clock->name);
 		current_clock = clock;
 		return 1;
 	} else {
-		log_info("%s: the rating of clock %s is not better than %s\n", __func__, clock->name, current_clock->name);
+		log_info("clock: the rating of clock %s is not better than %s\n", clock->name, current_clock->name);
 		return 0;
 	}
 }
@@ -38,25 +39,32 @@ void update_time(void)
 	nanos_t diff;
 	cycles_t cycles;
 
-	request_bh_run(BH_TIMER);
+	short saved_status;
+	LOCK(saved_status);
 
-	if (!current_clock)
-		return;
+	if (current_clock) {
+		cycles = current_clock->read(current_clock);
 
-	cycles = current_clock->read(current_clock);
+		// Check if the clock has overflowed
+		if (cycles == current_clock_last_cycle) {
+			// If no change, then do nothing and return
+			UNLOCK(saved_status);
+			return;
+		} else if (cycles > current_clock_last_cycle) {
+			diff = cycles - current_clock_last_cycle;
+		} else {
+			diff = (current_clock->max_cycles - current_clock_last_cycle) + cycles;
+		}
+		current_clock_last_cycle = cycles;
 
-	// Check if the clock has overflowed
-	if (cycles == current_clock_last_cycle) {
-		return;
-	} else if (cycles < current_clock_last_cycle) {
-		diff = (current_clock->max_cycles - current_clock_last_cycle) + cycles;
+		// Convert to nanoseconds
+		diff = current_clock->cycles_to_nanos(current_clock, diff);
 	} else {
-		diff = cycles;
+		// If there's no current clock, just increase the clock by a bit
+		// This function should be called periodically whenever an irq occurs, which could
+		// be any length of time.  A fixed amount is better than nothing
+		diff = 1000000;
 	}
-	current_clock_last_cycle = cycles;
-
-	// Convert to nanoseconds
-	diff = current_clock->cycles_to_nanos(current_clock, diff);
 
 	// Update monotonic uptime
 	monotonic_uptime_nanos += diff;
@@ -67,6 +75,10 @@ void update_time(void)
 		system_subseconds_nanos -= NANOS_PER_SECOND;
 		system_seconds += 1;
 	}
+
+	request_bh_run(BH_TIMER);
+
+	UNLOCK(saved_status);
 }
 
 void set_system_time(time_t t)

--- a/src/kernel/time.c
+++ b/src/kernel/time.c
@@ -47,7 +47,6 @@ void update_time(void)
 	if (current_clock) {
 		cycles = current_clock->read(current_clock);
 
-		// Check if the clock has overflowed
 		if (cycles == current_clock_last_cycle) {
 			// If no change, then do nothing and return
 			UNLOCK(saved_status);
@@ -55,6 +54,7 @@ void update_time(void)
 		} else if (cycles > current_clock_last_cycle) {
 			diff = cycles - current_clock_last_cycle;
 		} else {
+			// If the clock has overflowed
 			diff = (current_clock->max_cycles - current_clock_last_cycle) + cycles;
 		}
 		current_clock_last_cycle = cycles;

--- a/src/kernel/time.c
+++ b/src/kernel/time.c
@@ -6,13 +6,13 @@
 #include <kernel/irq/bh.h>
 
 
+struct clocksource *current_clock;
 static time_t system_seconds;
 static time_t system_subseconds_nanos;
 static cycles_t current_clock_last_cycle;
 static nanos_t monotonic_uptime_nanos;
-static char clock_warning_given = 0;
 
-struct clocksource *current_clock;
+static char clock_warning_given = 0;
 
 void init_time(void)
 {
@@ -64,7 +64,7 @@ void update_time(void)
 	} else {
 		if (!clock_warning_given) {
 			clock_warning_given = 1;
-			log_error("clock: no clock was set, defaulting to rough counting\n");
+			log_warning("clock: no clock was set, defaulting to rough counting\n");
 		}
 		// If there's no current clock, just increase the clock by a bit
 		// This function should be called periodically whenever an irq occurs, which could

--- a/src/libc/os/time/stime.c
+++ b/src/libc/os/time/stime.c
@@ -1,5 +1,5 @@
 
-#include <sys/types.h>
+#include <time.h>
 #include <sys/syscall.h>
 
 int stime(const time_t *t)

--- a/src/libc/os/time/time.c
+++ b/src/libc/os/time/time.c
@@ -1,5 +1,5 @@
 
-#include <sys/types.h>
+#include <time.h>
 #include <sys/syscall.h>
 
 time_t time(time_t *t)

--- a/todo.txt
+++ b/todo.txt
@@ -1,4 +1,6 @@
 
+* fix bug with signals, where setting the proc alarm to 0 will make it occur right away, and will always crash the problem due to stack corruption of some kind
+
 * so I'm currently left with two bugs, one is where it will continuously bus error on the same address and same pid, pid 4 which is
   the shell that runs the rc script.  This only happens if clock source isn't registered, which I would expect instead for it to
   block forever on the signal timer.  I think this is related to scheduling, and maybe means there's a missing reschedule request

--- a/todo.txt
+++ b/todo.txt
@@ -1,4 +1,10 @@
 
+* so I'm currently left with two bugs, one is where it will continuously bus error on the same address and same pid, pid 4 which is
+  the shell that runs the rc script.  This only happens if clock source isn't registered, which I would expect instead for it to
+  block forever on the signal timer.  I think this is related to scheduling, and maybe means there's a missing reschedule request
+* the other bug is that when the clock is registered, so normal conditions, the ntpdate command fails with a bus error for a very
+  odd address.  It happens just after the signal handler returns
+
 * make it possible to use other devices as timer interrupts, like an MC68230
 
 * document the partition vs raw disk image thing

--- a/todo.txt
+++ b/todo.txt
@@ -11,6 +11,7 @@
 
 * document the partition vs raw disk image thing
 * document (and make configurable) the LED output on the 68681, used to indicate a context switch
+* should you add -Wconversion (or -Wextra or something that includes it) to catch implicit conversions?  Generates a lot of warnings currently
 * should you add a name to the driver struct?
 * for all drivers, check that they all have valid pointers to a function (or do filesystems automatically substitute nop?)
 * need to make language consistent, duplicate vs clone vs something better?  alloc vs ?  make_ref vs clone? free vs release?


### PR DESCRIPTION
I'm trying to make a better abstraction for clocks and timekeeping in the kernel.  This borrows from Linux's clocksource drivers.  It provides a way for the kernel to read the current clock count, and then convert that count into nanoseconds, which is used to adjust the system time.  The clock and cycle count is assumed to be monotonic (will never jump backwards).  With the new `update_time()` function, it just needs to be called periodically in order check the registered clock's latest count, and adjust the time accordingly.  It will also schedule its own timer bottom half, which will check the timers and scheduler to ensure they run.

The MC68681 driver provides a clocksource, but others can be added to `kernel/drivers/clock`.  The 68681 timer cannot read the counter value while it is counting, which is a bit of a problem, so it can't produce a running ticks count.  The timeout has been changed to 10ms, with the scheduler preempting tasks every ~100ms.  I've also refactored the LED control for debugging, so it can be implemented by other hardware devices.

Also
- fixed 

## TODO
- [x] change the tty68681 driver to use a shorter, configurable time, like 10ms, instead of 71.11111ms
- [ ] add a work-timer test on boot, if and only if a better clock isn't registered
- [ ] fix the bug causing timeout signal handler to fail

## Commits

- [Added configurable clock source, and improved timing]

Now there's one function, `update_time`, which should be called
regularly in order to update the time using the configured clock.  It
will request a timer bottom half to be run, which then handles checking
the timers and the scheduler.

- [Fixed some programs crashing when using signal alarms/timeouts]

When it boots, it runs ntpdate, which times out, and just after the
timeout, it was crashing.  That was caused by the timer expiring too
soon.  That should be fixed as well, but I was also planning to make
signal handling happen before returning to that process, which might fix
that.

The timer was expiring too soon because the wrong value was being used
by update_time, and time was racing ahead.

I added a dummy minimum value, since update_time is called in the irq
return, it will update time by a bit if there's no current_clock
selected.

The issue with getting a page fault continuously was fixed by adjusting
the arch_extended_switch_context not being called correctly.  It was
getting into a state where the CRP register was pointing to a previous
process's memory_map, after an exec had been done.  I haven't see it do
that again, but I'm not 100% confident I fixed it