### PR TITLE
Fixed bugs with ext2

### DIFF
--- a/log.txt
+++ b/log.txt
@@ -6237,3 +6237,29 @@ with short descriptors, initial shift: 4, levels: 1, table entries: 8192, page: 
   that for being worse, but actually, it's trying to build the `bare-tests` goal when it recurses into the src/libc/ subdir, which
   is why it fails earlier
 
+- when I start poking a bit, I find a ton of bugs.  The issue that broke the bare-tests when the if condition around the test rules
+  include wasn't working was that the fs test directory had no tests, which caused it to fail because the test rules weren't
+  included, so there was no bare-tests rule
+- when I fixed that, I realized the bitmap unit test wasn't working, and it was because the last block group was 0x8000 blocks,
+  which wasn't noticed because I was created a disk 0x8000 blocks in size
+- It was because the conditional check was backwards.  Once I fixed that, it was still giving problems with a smaller disk
+- the whole time, if the disk wasn't 0x8000 blocks, when I `ls /media` it would fail with -1 permissions, and `cd`ing to it would
+  give -20 no dir, which means the inode's mode is 0
+- when I mounted the disk in linux, it reported fine, but when I tried to transfer a file, in then said it was read only, and after
+  unmounting, only then did fsck report an error
+- It said that thing about the number of size in blocks of a file being wrong, and I saw *again* that it was supposed to be 512-byte
+  sectors, and not fs blocks, so I fixed the calculation
+
+- other fsck errors reported are: dirs count wrong (2: counted=1), padding at end of block and inode bitmaps, and inode bitmap
+  differences: -11
+
+
+2026-06-04:
+
+- the issue with a drive that was 0x7000 blocks was that, when it loaded the superblock, it was dividing the total blocks by the
+  blocks_per_group value, which gave 1 fewer groups (ie. 0 groups), which then made it fail
+- perhaps troublesomely, it was still trying to read group 0 despite there being no groups, which should be a problem.  Either I
+  need to have an error if there's 0 groups when mounting, or else I need to have better checks, or both.  Not sure if it's an edge
+  case with 0 groups, or if it would try to read group 1 if there was only 1 group.
+- oh, I do have a check for num_groups in inodes, but it's a > instead of >= so it wasn't catching the off by one error
+

--- a/src/kernel/fs/ext2/bitmaps.h
+++ b/src/kernel/fs/ext2/bitmaps.h
@@ -27,8 +27,9 @@ static int bitmap_init(struct bufcache *bufcache, ext2_block_t bitmap_blocknum, 
 	struct buf *buf;
 
 	buf = get_block(bufcache, bitmap_blocknum);
-	if (!buf)
+	if (!buf) {
 		return -1;
+	}
 	block = buf->block;
 
 	const int last_byte = num_entries >> 3;

--- a/src/kernel/fs/ext2/inodes.h
+++ b/src/kernel/fs/ext2/inodes.h
@@ -25,7 +25,7 @@ static inline int get_inode_group(struct mount *mp, inode_t ino)
 {
 	const struct ext2_super *super = EXT2_SUPER(mp->super);
 	const int group = (ino - 1) >> super->log_inodes_per_group;
-	if (group > super->num_groups) {
+	if (group >= super->num_groups) {
 		return EINVAL;
 	}
 	return group;
@@ -35,7 +35,7 @@ static inline struct inode_location get_inode_block_and_offset(struct mount *mp,
 {
 	const struct ext2_super *super = EXT2_SUPER(mp->super);
 	const int group = (ino - 1) >> super->log_inodes_per_group;
-	if (group > super->num_groups) {
+	if (group >= super->num_groups) {
 		const struct inode_location result = { EINVAL, 0 };
 		return result;
 	}
@@ -44,6 +44,7 @@ static inline struct inode_location get_inode_block_and_offset(struct mount *mp,
 	const ext2_block_t block_offset = group_inode >> super->log_inodes_per_block;
 	const int byte_offset = alignment_offset(group_inode, 1 << super->log_inodes_per_block) << super->log_inode_size;
 	const struct inode_location result = { super->groups[group].inode_table + block_offset, byte_offset };
+
 	return result;
 }
 
@@ -163,7 +164,7 @@ static int write_inode(struct vnode *vnode, inode_t ino)
 	inode->mode = htole16(vnode->mode);
 	inode->uid = htole16(vnode->uid);
 	inode->size = htole32(vnode->size);
-	inode->nblocks = htole32((vnode->size >> EXT2_LOG_BLOCK_SIZE(block_size)) + (vnode->size & (block_size - 1) ? 1 : 0));
+	inode->nblocks = htole32(((vnode->size >> 9) + (vnode->size & (block_size - 1) ? 1 : 0)));	// total number of 512-byte blocks
 	inode->atime = htole32(vnode->atime);
 	inode->mtime = htole32(vnode->mtime);
 	inode->ctime = htole32(vnode->ctime);

--- a/src/kernel/fs/ext2/mkfs.h
+++ b/src/kernel/fs/ext2/mkfs.h
@@ -102,16 +102,13 @@ static int ext2_mkfs(device_t dev, const struct mkfs_options *opts)
 		groups[group].block_bitmap = group_start + superblock_blocknum + 1 + group_descriptor_blocks;
 		groups[group].inode_bitmap = groups[group].block_bitmap + 1;
 		groups[group].inode_table = groups[group].block_bitmap + 2;
-		groups[group].free_block_count = super.super.blocks_per_group - group_reserved_blocks;
-		groups[group].free_inode_count = super.super.inodes_per_group - group_reserved_inodes;
+		groups[group].free_block_count = super.super.blocks_per_group;
+		groups[group].free_inode_count = super.super.inodes_per_group;
 		groups[group].used_dirs_count = 0;
 
-		if (group_start + super.super.blocks_per_group < super.super.total_blocks) {
-			groups[group].free_block_count = super.super.total_blocks - group_start - group_reserved_blocks;
+		if (group_start + super.super.blocks_per_group > super.super.total_blocks) {
+			groups[group].free_block_count = super.super.total_blocks - group_start;
 		}
-
-		super.super.total_unalloc_blocks -= group_reserved_blocks;
-		super.super.total_unalloc_inodes -= group_reserved_inodes;
 
 		if (groups[group].inode_table + inode_table_blocks > super.super.total_blocks) {
 			log_error("last block group is too small\n");
@@ -120,14 +117,19 @@ static int ext2_mkfs(device_t dev, const struct mkfs_options *opts)
 		}
 
 		// Initialize bitmap blocks
-		error = bitmap_init(&mp.bufcache, groups[group].block_bitmap, super.super.blocks_per_group, group_reserved_blocks);
+		error = bitmap_init(&mp.bufcache, groups[group].block_bitmap, groups[group].free_block_count, group_reserved_blocks);
 		if (error < 0) {
 			goto fail;
 		}
-		error = bitmap_init(&mp.bufcache, groups[group].inode_bitmap, super.super.inodes_per_group, group_reserved_inodes);
+		error = bitmap_init(&mp.bufcache, groups[group].inode_bitmap, groups[group].free_inode_count, group_reserved_inodes);
 		if (error < 0) {
 			goto fail;
 		}
+
+		groups[group].free_block_count -= group_reserved_blocks;
+		groups[group].free_inode_count -= group_reserved_inodes;
+		super.super.total_unalloc_blocks -= group_reserved_blocks;
+		super.super.total_unalloc_inodes -= group_reserved_inodes;
 
 		// Zero the inode table
 		for (int i = 0; i < inode_table_blocks; i++) {

--- a/src/kernel/fs/ext2/super.h
+++ b/src/kernel/fs/ext2/super.h
@@ -93,7 +93,13 @@ static int load_superblock(struct mount *mp)
 		return EINVAL;
 	}
 
-	const int num_groups = le32toh(super_on_disk->total_blocks) / le32toh(super_on_disk->blocks_per_group);
+	const int total_blocks = le32toh(super_on_disk->total_blocks);
+	const int blocks_per_group = le32toh(super_on_disk->blocks_per_group);
+	const int num_groups = (total_blocks / blocks_per_group) + (total_blocks & (blocks_per_group - 1) ? 1 : 0);
+
+	if (num_groups <= 0) {
+		log_error("%s: error mounting filesystem, calculated 0 block groups\n", mp->ops->fstype);
+	}
 
 	super = kmalloc(sizeof(struct ext2_super) + (num_groups * sizeof(struct ext2_block_group)));
 	super->groups = (struct ext2_block_group *) (super + 1);	// the area just after the superblock, allocated along with it
@@ -147,6 +153,7 @@ static int load_superblock(struct mount *mp)
 		super->groups[group].free_block_count = le16toh(group_on_disk->free_block_count);
 		super->groups[group].free_inode_count = le16toh(group_on_disk->free_inode_count);
 		super->groups[group].used_dirs_count = le16toh(group_on_disk->used_dirs_count);
+
 	}
 	if (buf) {
 		release_block(buf, 0);

--- a/tests/entry.c
+++ b/tests/entry.c
@@ -3,16 +3,20 @@
  */
 
 #include <stdio.h>
+#include <kconfig.h>
 
 extern int main(void);
 extern int init_tty(void);
+extern void init_heap(void *addr, unsigned long size);
 
+__attribute__((section(".text.startup")))
 void _start(void)
 {
 	/* Disable interrupts */
 	asm volatile("move.w	#0x2700, %sr\n");
 
 	init_tty();
+	init_heap((void *) CONFIG_PAGES_START, CONFIG_PAGES_END - CONFIG_PAGES_START);
 	main();
 
 	asm volatile("stop	#0x2700\n");

--- a/tests/kernel/fs/Makefile
+++ b/tests/kernel/fs/Makefile
@@ -1,3 +1,5 @@
 
+tests-y		+= ext2/
+
 libex-y		+= src/libc/libc-$(SRCARCH)-none.a
 

--- a/tests/kernel/fs/bufcache_mock.c
+++ b/tests/kernel/fs/bufcache_mock.c
@@ -59,6 +59,6 @@ int release_block(struct buf *buf, short dirty)
 
 void mark_block_dirty(struct buf *buf)
 {
-	buf->flags |= BCF_DIRTY;
+	buf->flags |= BF_DIRTY;
 }
 

--- a/tests/kernel/fs/bufcache_mock.c
+++ b/tests/kernel/fs/bufcache_mock.c
@@ -6,13 +6,14 @@
 
 #define MAX_TEST_BUFS		100
 
-int mock_block_size = 0;
 struct buf mock_bufs[MAX_TEST_BUFS];
 
 void init_bufcache(struct bufcache *cache, device_t dev, int block_size)
 {
-	mock_block_size = block_size;
-
+	cache->dev = dev;
+	cache->flags = 0;
+	cache->block_size = block_size;
+	cache->num_entries = MAX_TEST_BUFS;
 	for (int i = 0; i < MAX_TEST_BUFS; i++) {
 		_queue_node_init(&mock_bufs[i].node);
 		mock_bufs[i].refcount = 0;

--- a/tests/kernel/fs/ext2/Makefile
+++ b/tests/kernel/fs/ext2/Makefile
@@ -1,7 +1,8 @@
 
-tests-y			+= bitmaps_test.o
-#tests-y			+= inodes_test.o
+tests-y		+= bitmaps_test.o
+#tests-y	+= inodes_test.o
 
-tests-obj-y		+= tests/kernel/fs/bufcache_mock.o
-tests-obj-y		+= tests/printk.o
+tests-obj-y	+= tests/kernel/fs/bufcache_mock.o
+
+libex-y		+= src/libc/libc-$(SRCARCH)-none.a
 

--- a/tests/kernel/fs/ext2/Makefile
+++ b/tests/kernel/fs/ext2/Makefile
@@ -2,6 +2,6 @@
 tests-y			+= bitmaps_test.o
 #tests-y			+= inodes_test.o
 
-tests-obj-y		+= $(src-root)/tests/kernel/fs/bufcache_mock.host.o
-tests-obj-y		+= $(src-root)/tests/printk.host.o
+tests-obj-y		+= tests/kernel/fs/bufcache_mock.o
+tests-obj-y		+= tests/printk.o
 

--- a/tests/kernel/fs/ext2/bitmaps_test.c
+++ b/tests/kernel/fs/ext2/bitmaps_test.c
@@ -17,7 +17,7 @@ int test_bitmap_alloc_free(void)
 	struct bufcache bufcache;
 	const block_t bitmap_blocknum = 0;
 
-	init_bufcache(&bufcache, 0, TEST_BLOCK_SIZE);
+	init_bufcache(&bufcache, 101, TEST_BLOCK_SIZE);
 	uint8_t *bitmap_data = mock_bufs[bitmap_blocknum].block;
 
 	// Initialize bitmap and verify it's correct
@@ -62,5 +62,7 @@ int main()
 {
 	run(test_bitmap_alloc_free);
 
-	printf("bitmap tests passed\n");
+	printf("%s tests passed\n", __FILE_NAME__);
+
+	return 0;
 }

--- a/tests/kernel/fs/ext2/bitmaps_test.c
+++ b/tests/kernel/fs/ext2/bitmaps_test.c
@@ -14,7 +14,6 @@ extern struct buf mock_bufs[];
 int test_bitmap_alloc_free(void)
 {
 	bitnum_t bit;
-	uint32_t bits_value;
 	struct bufcache bufcache;
 	const block_t bitmap_blocknum = 0;
 
@@ -24,7 +23,7 @@ int test_bitmap_alloc_free(void)
 	// Initialize bitmap and verify it's correct
 	bitmap_init(&bufcache, bitmap_blocknum, 20, 1);
 	printk_dump_bytes(bitmap_data, 4);
-	assert(!memcmp(bitmap_data, "\x01\x00\xF0\xFF", 4));
+	assert(!memcmp(bitmap_data, "\x01\x00\x0F\xFF", 4));
 
 	bit = bit_alloc(&bufcache, bitmap_blocknum, 0);
 	assert(bit != 0);
@@ -39,18 +38,18 @@ int test_bitmap_alloc_free(void)
 	printk("allocated %d\n", bit);
 
 	printk_dump_bytes(bitmap_data, 4);
-	assert(!memcmp(bitmap_data, "\x0F\x00\xF0\xFF", 4));
+	assert(!memcmp(bitmap_data, "\x0F\x00\x0F\xFF", 4));
 
 	printk("freeing 1\n");
 	bit_free(&bufcache, bitmap_blocknum, 1);
 	printk_dump_bytes(bitmap_data, 4);
-	assert(!memcmp(bitmap_data, "\x0D\x00\xF0\xFF", 4));
+	assert(!memcmp(bitmap_data, "\x0D\x00\x0F\xFF", 4));
 
 	bit = bit_alloc(&bufcache, bitmap_blocknum, 0);
 	assert(bit != 0);
 	printk("allocated %d\n", bit);
 	printk_dump_bytes(bitmap_data, 4);
-	assert(!memcmp(bitmap_data, "\x0F\x00\xF0\xFF", 4));
+	assert(!memcmp(bitmap_data, "\x0F\x00\x0F\xFF", 4));
 
 	return 0;
 }

--- a/tests/kernel/mm/pages_test.c
+++ b/tests/kernel/mm/pages_test.c
@@ -90,5 +90,7 @@ int main()
 	run(test_page_single_allocation);
 	run(test_page_contiguous_allocation);
 
-	printf("pages tests passed\n");
+	printf("%s tests passed\n", __FILE_NAME__);
+
+	return 0;
 }

--- a/tests/kernel/utils/iovec_test.c
+++ b/tests/kernel/utils/iovec_test.c
@@ -136,7 +136,7 @@ int main(void)
 	run(test_iovec_kvec_seek);
 	run(test_iovec_kvec_copy);
 
-	printf("All tests completed\n");
+	printf("%s tests passed\n", __FILE_NAME__);
 
 	return 0;
 }

--- a/tests/kernel/utils/queue_test.c
+++ b/tests/kernel/utils/queue_test.c
@@ -17,7 +17,7 @@ void print_queue(struct queue *queue)
 	printf("\n");
 }
 
-int main()
+int test_queue_insert_remove(void)
 {
 	struct queue_node node1;
 	struct queue_node node2;
@@ -52,6 +52,19 @@ int main()
 	printf("done\n");
 
 	print_queue(&queue2);
+
+	return 0;
+}
+
+#define run(test) \
+	printf("Running %s\n", #test); \
+	assert(test() == 0);
+
+int main(void)
+{
+	run(test_queue_insert_remove);
+
+	printf("%s tests passed\n", __FILE_NAME__);
 
 	return 0;
 }

--- a/tests/kernel/utils/ringbuffer_test.c
+++ b/tests/kernel/utils/ringbuffer_test.c
@@ -6,7 +6,7 @@
 
 #define BUF_SIZE	16
 
-int main()
+int test_ringbuffer_insert_wrap_around(void)
 {
 	struct ringbuffer buffer;
 
@@ -82,6 +82,19 @@ int main()
 		//assert(array[i] == array2[i]);
 	}
 	printf("\n");
+
+	return 0;
+}
+
+#define run(test) \
+	printf("Running %s\n", #test); \
+	assert(test() == 0);
+
+int main(void)
+{
+	run(test_ringbuffer_insert_wrap_around);
+
+	printf("%s tests passed\n", __FILE_NAME__);
 
 	return 0;
 }

--- a/tests/kernel/utils/strarray_test.c
+++ b/tests/kernel/utils/strarray_test.c
@@ -6,7 +6,7 @@
 #include <kernel/utils/strarray.h>
 
 
-int main(void)
+int test_strarray_init_copy(void)
 {
 	int num_args = 3;
 	struct string_array array;
@@ -43,6 +43,19 @@ int main(void)
 	assert(((uintptr_t *) buffer)[0] == (uintptr_t) &buffer[arg0_start]);
 	assert(((uintptr_t *) buffer)[1] == (uintptr_t) &buffer[arg0_start + 5]);
 	assert(((uintptr_t *) buffer)[2] == (uintptr_t) &buffer[arg0_start + 10]);
+
+	return 0;
+}
+
+#define run(test) \
+	printf("Running %s\n", #test); \
+	assert(test() == 0);
+
+int main(void)
+{
+	run(test_strarray_init_copy);
+
+	printf("%s tests passed\n", __FILE_NAME__);
 
 	return 0;
 }

--- a/todo.txt
+++ b/todo.txt
@@ -1,4 +1,6 @@
 
+* you should probably modify roundup to be more standard, and make new versions in macros.h just for the kernel, that do the more specific non-dividing functions you need for addresses
+
 * should you move the reference increment to inside memory_map_mmap?  It would be a bit weird in that a file/region passed into mmap would not have the reference captured, but
   instead expect the caller to still free their own reference.  Most other functions don't operate like that
 

--- a/tools/build/Makefile.build
+++ b/tools/build/Makefile.build
@@ -115,7 +115,6 @@ $(OUTPUT)%.send: $(OUTPUT)%.bin
 $(OUTPUT)%.bin: $(OUTPUT)%.elf
 	$(cmd_ld_bin)
 
-#.PRECIOUS: $(OUTPUT)%.elf
 $(OUTPUT)%/$(notdir $(dir)).elf: $(OUTPUT)%/built-in.o
 	$(cmd_ld_elf)
 

--- a/tools/build/Makefile.test
+++ b/tools/build/Makefile.test
@@ -16,12 +16,14 @@ bare-tests-obj-y	+= $(tests-obj-y)
 host-tests-auto-obj	:= tests/printk.host.o
 host-tests-common-deps	:= $(host-tests-auto-obj) $(host-tests-obj-y)
 
-bare-tests-auto-obj	:= tests/entry.o tests/printk.o src/monitor/tty_68681.o
+bare-tests-start	:= tests/entry.o
+bare-tests-auto-obj	:= tests/printk.o src/monitor/tty_68681.o
 bare-tests-common-deps	:= $(bare-tests-auto-obj) $(bare-tests-obj-y)
 
 ### Add prefix to all applicable targets
 host-tests-common-deps	:= $(addprefix $(OUTPUT),$(host-tests-common-deps))
 bare-tests-common-deps	:= $(addprefix $(OUTPUT),$(bare-tests-common-deps))
+bare-tests-start	:= $(addprefix $(OUTPUT),$(bare-tests-start))
 
 ### Rules
 
@@ -34,7 +36,8 @@ bare-tests: $(config-h) $(tests-main-subdir-y) $(bare-tests-load)
 $(OUTPUT)%.test.run: $(OUTPUT)%.test.host
 	./$<
 
-$(OUTPUT)%.test.host: HOST_CFLAGS += -DHOST_TARGET -DHOST_TEST
+#PRECIOUS += $(OUTPUT)%.test.host
+$(OUTPUT)%.test.host: HOST_CFLAGS += -DHOST_TARGET -DHOST_TEST -DTEST
 $(OUTPUT)%.test.host: $(OUTPUT)%.host.o $(host-tests-common-deps)
 	$(cmd_host_ld_elf)
 
@@ -45,10 +48,13 @@ $(OUTPUT)%.test.load: ccflags-y += $(firmware-ccflags-y)
 $(OUTPUT)%.test.load: $(OUTPUT)%.bin
 	tools/make-load-file $< $@ $(LOAD_ARGS)
 
-$(OUTPUT)%.test.bin: $(OUTPUT)%.o $(bare-tests-common-deps) $(libex-obj-y)
+$(OUTPUT)%.test.bin: CFLAGS += -DTEST
+$(OUTPUT)%.test.bin: $(bare-tests-start) $(OUTPUT)%.o $(bare-tests-common-deps) $(libex-obj-y)
 	$(cmd_ld_bin)
+	# build an identical elf file for easier test debugging
+	$(patsubst %.bin,%.elf,$(cmd_ld_elf))
 
-obj-dirs := $(sort $(patsubst %/,%, $(dir $(tests-main-subdir-y) $(tests-main-obj-y))))
+obj-dirs := $(sort $(patsubst %/,%, $(dir $(tests-main-subdir-y) $(tests-main-obj-y) $(host-tests-common-deps) $(bare-tests-common-deps))))
 ifneq ($(obj-dirs),)
 $(shell mkdir -p $(obj-dirs))
 endif


### PR DESCRIPTION
Fixed bugs with ext2

- the nblocks value was incorrect, should be the number of 512-byte blocks, not file system blocks
- the last group was not trucated to the total number of blocks in the disk, so it was technically creating a block group past the end of the disk
- when mounting a disk that only had one block group, it would calculate the number of groups to be 0, and continue anyways, which meant the inode table block number was 0 and it was reading an inode with mode=0

Fixed bugs in tests

- fixed bufcache_mock.c to use the correct block size
- modified to place the _start function first in the binary
- added malloc heap initialization to entry.c (all tests were failing
  when run)
- normalized test file main() functions, with normalized messaging
- added dependencies to the list of directories that are forced to be
  created