### PR TITLE
Added page alloc flags, and multiple page blocks

### DIFF
--- a/include/kernel/mm/pages.h
+++ b/include/kernel/mm/pages.h
@@ -30,14 +30,12 @@
 
 #define PAGE_SIZE	(1 << PAGE_ADDR_BITS)
 
-#define PAGE_TYPE	0x0007		/// Bits that specify the type of page to allocate
-#define PAGE_KERNEL	0x0001		/// A page used by the kernel itself
-#define PAGE_USER	0x0002		/// A page used by a user process
-#define PAGE_LOCAL	0x0010		/// The page must be in local memory (fast access)
-#define PAGE_NOFAIL	0x8000		/// Always return a page (using pages allocated for emergencies)
-
-char *page_alloc(int pages);
-void page_free(char *ptr);
+#define PAGE_F_NOFAIL		0x8000		/// Always return a page (using pages allocated for emergencies)
+#define PAGE_F_SUPERVISOR	0x4000		/// A page used by the kernel itself
+#define PAGE_F_TYPE		0x000F		/// Bits that specify the type of page to allocate
+#define PAGE_F_LOCAL		0x0001		/// The page must be in local memory (fast access)
+#define PAGE_F_SHARED		0x0002		/// The page must be in shared memory (available to all cpus)
+#define PAGE_F_USER		0x0000		/// The default settings for user memory
 
 
 #define ALL_PAGES_AT_INDEX	((uint16_t) 0xffffffff)
@@ -59,18 +57,28 @@ struct page_domain {
 
 struct page_block {
 	struct queue_node node;
-	bitmap_t *bitmap;
+	uint32_t flags;
+	int total_pages;
+	int free_pages;
+	physical_address_t base;
+	size_t end;
 	int bitmap_size;
-	page_t *base;
-	int pages;
+	bitmap_t *bitmap;
 	#if defined(CONFIG_MMU)
 	struct page_descriptor *page_descriptors;
 	#endif
 };
 
+int init_pages(physical_address_t start, size_t size, uint32_t flags);
+physical_address_t page_alloc(size_t size, uint32_t flags);
+void page_free(physical_address_t ptr, size_t size);
+#if defined(CONFIG_MMU)
+physical_address_t page_make_ref(physical_address_t ptr, size_t size);
+int page_get_ref_single(physical_address_t ptr);
+#endif
 
-int init_page_block_with_bitmap(struct page_block *block, bitmap_t *bitmap, int bitmap_size, void *addr, size_t size, struct page_descriptor *descriptors);
-int init_page_block(struct page_block *block, void *addr, size_t size);
+int init_page_block_with_bitmap(struct page_block *block, size_t size, physical_address_t addr, bitmap_t *bitmap, int bitmap_size, struct page_descriptor *descriptors, uint32_t flags);
+int init_page_block(struct page_block *block, physical_address_t addr, size_t size, uint32_t flags);
 physical_address_t page_block_alloc(struct page_block *block, size_t size);
 void page_block_free(struct page_block *block, physical_address_t ptr, size_t size);
 #if defined(CONFIG_MMU)
@@ -84,13 +92,6 @@ static inline void zero_page(physical_address_t ptr)
 }
 
 extern struct page_block pages;
-#define init_pages(start, size)					init_page_block(&pages, (void *) start, size)
-#define page_alloc(contiguous_pages)				page_block_alloc(&pages, contiguous_pages)
-#define page_free(page, size)					page_block_free(&pages, page, size)
-#if defined(CONFIG_MMU)
-#define page_make_ref(page, size)				page_block_make_ref(&pages, page, size)
-#define page_get_ref_single(page)				page_block_get_ref_single(&pages, page)
-#endif
 
 #endif
 

--- a/log.txt
+++ b/log.txt
@@ -6299,3 +6299,12 @@ with short descriptors, initial shift: 4, levels: 1, table entries: 8192, page: 
 
 - I ended up going with a table of pointers, with the process struct allocated with kmalloc for each process.  It should work
   alright, while being a bit more space conscious
+
+
+2026-06-11:
+
+- I'm trying to decide on which flags to use, and was going to make one a mutually exclusive number for the type, but then realized
+  that LOCAL and SHARED (or maybe it should be FAST or SHARED), can be true at the same time?  Just writing that, I realized that
+  LOCAL is kind of the opposite of SHARED, so it could be one flag, and then another one for FAST (ie. close to the cpu)?  What
+  happens if no blocks can satisfy all the conditions?
+

--- a/src/kernel/arch/m68k/mm/mmu.c
+++ b/src/kernel/arch/m68k/mm/mmu.c
@@ -57,7 +57,7 @@ mmu_descriptor_t *mmu_table_alloc(void)
 {
 	mmu_descriptor_t *root_table;
 
-	root_table = (mmu_descriptor_t *) page_alloc(PAGE_SIZE);
+	root_table = (mmu_descriptor_t *) page_alloc(PAGE_SIZE, PAGE_F_SUPERVISOR);
 	init_mmu_table(root_table);
 
 	return root_table;
@@ -135,7 +135,7 @@ static inline int get_table(mmu_descriptor_t *root_table, virtual_address_t virt
 			if (MMU_DT(table[i]) == MMU_DT_INVALID) {
 				if (create_if_needed) {
 					// Create a new table since one hasn't already been created yet
-					next_table = (mmu_descriptor_t *) page_alloc(PAGE_SIZE);
+					next_table = (mmu_descriptor_t *) page_alloc(PAGE_SIZE, PAGE_F_USER);
 					init_mmu_table(next_table);
 
 					//printk("set new table %x [table: %x, i: %d, bits: %d]\n", next_table, table, i, bits);
@@ -225,7 +225,7 @@ int mmu_table_map(mmu_descriptor_t *root_table, uintptr_t virtual_addr, size_t l
 						break;
 					}
 					case MMU_TYPE_PREALLOCATED: {
-						physical_addr = (physical_address_t) page_alloc(PAGE_SIZE);
+						physical_addr = (physical_address_t) page_alloc(PAGE_SIZE, PAGE_F_USER);
 						status |= MMU_DT_PAGE_DESCRIPTOR;
 						break;
 					}

--- a/src/kernel/arch/m68k/proc/context.c
+++ b/src/kernel/arch/m68k/proc/context.c
@@ -77,7 +77,7 @@ int arch_init_task_info(struct process *proc)
 	#if defined(CONFIG_M68K_USER_MODE)
 
 	if (!proc->task_info.kernel_stack_start) {
-		proc->task_info.kernel_stack_start = (char *) page_alloc(KERNEL_STACK_SIZE);
+		proc->task_info.kernel_stack_start = (char *) page_alloc(KERNEL_STACK_SIZE, PAGE_F_USER);
 		if (!proc->task_info.kernel_stack_start) {
 			return ENOMEM;
 		}

--- a/src/kernel/main.c
+++ b/src/kernel/main.c
@@ -207,7 +207,7 @@ int main(void)
 	printk("\nBooting with \"%s\"...\n\n", boot_args);
 	parse_boot_args();
 
-	error = init_pages(PAGES_START, PAGES_END - PAGES_START);
+	error = init_pages(PAGES_START, PAGES_END - PAGES_START, PAGE_F_LOCAL | PAGE_F_SHARED);
 	if (error < 0)
 		goto fail;
 

--- a/src/kernel/mm/kmalloc.c
+++ b/src/kernel/mm/kmalloc.c
@@ -22,19 +22,14 @@ struct heap {
 	size_t bytes_allocated;
 };
 
-
-static struct page_block *kmem_page_block = &pages;
 static struct heap main_heap = { 0, 0, 0, 0 };
 
+#if defined(CONFIG_KMALLOC_PRIVATE)
 
-int init_kernel_heap(void)
-{
-	main_heap.free_blocks = NULL;
-	main_heap.total_pages = 0;
-	main_heap.bytes_free = 0;
-	main_heap.bytes_allocated = 0;
-	return 0;
-}
+#define kmalloc_page_alloc(size, flags)		page_block_alloc(&kmem_page_block, size, flags)
+#define kmalloc_page_free(ptr, size)		page_block_free(&kmem_page_block, ptr, size)
+
+static struct page_block *kmem_page_block = &pages;
 
 int kernel_heap_set_private_page_block(uintptr_t start, uintptr_t end)
 {
@@ -45,10 +40,26 @@ int kernel_heap_set_private_page_block(uintptr_t start, uintptr_t end)
 		return -1;
 	}
 
-	error = init_page_block(kmem_page_block, (char *) start, end - start);
+	error = init_page_block(kmem_page_block, 0, start, end - start);
 	if (error < 0) {
 		return error;
 	}
+	return 0;
+}
+
+#else
+
+#define kmalloc_page_alloc(size, flags)		page_alloc(size, flags)
+#define kmalloc_page_free(ptr, size)		page_free(ptr, size)
+
+#endif
+
+int init_kernel_heap(void)
+{
+	main_heap.free_blocks = NULL;
+	main_heap.total_pages = 0;
+	main_heap.bytes_free = 0;
+	main_heap.bytes_allocated = 0;
 	return 0;
 }
 
@@ -103,7 +114,7 @@ void *kmalloc(uintptr_t size)
 	// We're out of free blocks, so attempt to allocate a new page of memory, and panic
 	// if we've run out of pages
 	uintptr_t page_size = align_up(block_size, PAGE_SIZE);
-	cur = (struct block *) page_block_alloc(kmem_page_block, page_size);
+	cur = (struct block *) kmalloc_page_alloc(page_size, PAGE_F_SUPERVISOR);
 	if (!cur) {
 		// Out Of Memory
 		panic("Kernel out of memory!  Halting...\n");
@@ -160,8 +171,6 @@ void kmfree(void *ptr)
 		}
 
 		if (cur >= block) {
-
-
 			// Insert the free'd block into the list
 			if (prev) {
 				prev->next = block;
@@ -204,7 +213,7 @@ void kernel_heap_compact(void)
 				main_heap.free_blocks = cur->next;
 			}
 
-			page_block_free(kmem_page_block, (uintptr_t) cur, cur->size >> PAGE_ADDR_BITS);
+			kmalloc_page_free((uintptr_t) cur, cur->size >> PAGE_ADDR_BITS);
 
 			main_heap.bytes_free -= cur->size;
 			main_heap.total_pages -= cur->size;

--- a/src/kernel/mm/map.c
+++ b/src/kernel/mm/map.c
@@ -30,7 +30,7 @@ struct memory_region *memory_region_alloc_user_memory(size_t size, struct vfile 
 	if (!region)
 		goto fail;
 
-	memory = (char *) page_alloc(size);
+	memory = (char *) page_alloc(size, PAGE_F_USER);
 	if (!memory)
 		goto fail;
 
@@ -77,7 +77,7 @@ physical_address_t file_memory_ops_load_page_at(struct memory_segment *segment, 
 	physical_address_t page;
 	struct iovec_iter iter;
 
-	page = page_alloc(PAGE_SIZE);
+	page = page_alloc(PAGE_SIZE, PAGE_F_USER);
 	if (!page) {
 		return NULL;
 	}
@@ -111,7 +111,7 @@ physical_address_t anonymous_memory_ops_load_page_at(struct memory_segment *segm
 {
 	physical_address_t page;
 
-	page = page_alloc(PAGE_SIZE);
+	page = page_alloc(PAGE_SIZE, PAGE_F_USER);
 	if (!page) {
 		return NULL;
 	}
@@ -128,7 +128,7 @@ static inline int memory_map_convert_copy_on_write(struct memory_map *map, virtu
 	int error;
 	physical_address_t page_copy;
 
-	page_copy = page_alloc(page_size);
+	page_copy = page_alloc(page_size, PAGE_F_USER);
 	if (!page_copy) {
 		return ENOMEM;
 	}

--- a/src/kernel/mm/pages.c
+++ b/src/kernel/mm/pages.c
@@ -1,4 +1,5 @@
 
+#include <errno.h>
 #include <stdint.h>
 #include <string.h>
 
@@ -7,35 +8,39 @@
 #include <kernel/mm/pages.h>
 #include <kernel/utils/macros.h>
 
-struct page_block pages = { 0 };
+#define CONFIG_MAX_PAGE_BLOCKS	4
 
+static int num_global_blocks;
+static struct page_block global_blocks[CONFIG_MAX_PAGE_BLOCKS];
 
-int init_page_block_with_bitmap(struct page_block *block, bitmap_t *bitmap, int bitmap_size, void *addr, size_t size, struct page_descriptor *descriptors)
+int init_page_block_with_bitmap(struct page_block *block, size_t size, physical_address_t addr, bitmap_t *bitmap, int bitmap_size, struct page_descriptor *descriptors, uint32_t flags)
 {
 	_queue_node_init(&block->node);
+	block->flags = flags;
+	block->total_pages = size >> PAGE_ADDR_BITS;
+	block->free_pages = block->total_pages;
+	block->base = addr;
 	block->bitmap = bitmap;
 	block->bitmap_size = bitmap_size;
-	block->base = addr;
-	block->pages = size >> PAGE_ADDR_BITS;
 	memset(block->bitmap, '\0', block->bitmap_size);
 
 	#if defined(CONFIG_MMU)
 	block->page_descriptors = descriptors;
-	memset(block->page_descriptors, '\0', block->pages);
+	memset(block->page_descriptors, '\0', block->total_pages);
 	#endif
 
-	log_trace("pages %x to %x, %d pages, %d bitmap size\n", addr, addr + size, block->pages, block->bitmap_size);
+	log_trace("pages %x to %x, %d pages, %d bitmap size\n", addr, addr + size, block->total_pages, block->bitmap_size);
 	// Check that the bitmap is big enough, and return an error if it's too small
-	if ((bitmap_size << LOG_OF_PAGES_PER_INDEX) < block->pages) {
+	if ((bitmap_size << LOG_OF_PAGES_PER_INDEX) < block->total_pages) {
 		return -1;
 	}
 
 	return 0;
 }
 
-int init_page_block(struct page_block *block, void *addr, size_t size)
+int init_page_block(struct page_block *block, physical_address_t addr, size_t size, uint32_t flags)
 {
-	void *pages_addr;
+	physical_address_t pages_addr;
 	int descriptors_pages = 0;
 	int total_pages, allocatable_pages;
 	int bitmap_size, bitmap_pages;
@@ -56,14 +61,87 @@ int init_page_block(struct page_block *block, void *addr, size_t size)
 	#endif
 
 	allocatable_pages = total_pages - bitmap_pages - descriptors_pages;
-	pages_addr = &((page_t *) addr)[bitmap_pages + descriptors_pages];
+	pages_addr = (physical_address_t) &((page_t *) addr)[bitmap_pages + descriptors_pages];
 
 	log_trace("bitmaps at %x, size %d, pages %d, after %x\n", addr, bitmap_size, bitmap_pages, pages_addr);
 	#if defined(CONFIG_MMU)
 	log_trace("descriptors at %x, size %d, pages %d, after %x\n", descriptors_addr, descriptors_size, descriptors_pages, pages_addr);
 	#endif
-	return init_page_block_with_bitmap(block, (bitmap_t *) addr, bitmap_size, pages_addr, allocatable_pages << PAGE_ADDR_BITS, descriptors_addr);
+	return init_page_block_with_bitmap(block, allocatable_pages << PAGE_ADDR_BITS, pages_addr, (bitmap_t *) addr, bitmap_size, descriptors_addr, flags);
 }
+
+int append_global_page_block(physical_address_t start, size_t size, uint32_t flags)
+{
+	if (num_global_blocks > 0) {
+		const size_t previous_last_block_end = global_blocks[num_global_blocks].base + (global_blocks[num_global_blocks].total_pages * PAGE_SIZE);
+		if (start < previous_last_block_end) {
+			log_debug("pages: overlapping page block (note: they must be added in ascending order)\n");
+			return EINVAL;
+		}
+	}
+
+	num_global_blocks += 1;
+	return init_page_block(&global_blocks[num_global_blocks - 1], start, size, flags);
+}
+
+int init_pages(physical_address_t start, size_t size, uint32_t flags)
+{
+	int error;
+
+	num_global_blocks = 0;
+
+	error = append_global_page_block(start, size, flags);
+	if (error < 0)
+		return error;
+
+	return 0;
+}
+
+physical_address_t page_alloc(size_t size, uint32_t flags)
+{
+	const int contiguous_pages = size >> PAGE_ADDR_BITS;
+
+	for (int i = 0; i < num_global_blocks; i++) {
+		if ((global_blocks[i].flags & (PAGE_F_TYPE & flags)) == (PAGE_F_TYPE & flags) && global_blocks[i].free_pages > contiguous_pages) {
+			return page_block_alloc(&global_blocks[i], size);
+		}
+	}
+	return NULL;
+}
+
+void page_free(physical_address_t ptr, size_t size)
+{
+	for (int i = 0; i < num_global_blocks; i++) {
+		if (ptr >= global_blocks[i].base && ptr <= global_blocks[i].base + (global_blocks[i].total_pages * PAGE_SIZE)) {
+			page_block_free(&global_blocks[i], ptr, size);
+			return;
+		}
+	}
+}
+
+#if defined(CONFIG_MMU)
+
+physical_address_t page_make_ref(physical_address_t ptr, size_t size)
+{
+	for (int i = 0; i < num_global_blocks; i++) {
+		if (ptr >= global_blocks[i].base && ptr <= global_blocks[i].base + (global_blocks[i].total_pages * PAGE_SIZE)) {
+			page_block_make_ref(&global_blocks[i], ptr, size);
+		}
+	}
+	return NULL;
+}
+
+int page_get_ref_single(physical_address_t ptr)
+{
+	for (int i = 0; i < num_global_blocks; i++) {
+		if (ptr >= global_blocks[i].base && ptr <= global_blocks[i].base + (global_blocks[i].total_pages * PAGE_SIZE)) {
+			page_block_get_ref_single(&global_blocks[i], ptr);
+		}
+	}
+	return 0;
+}
+
+#endif
 
 /// Allocate one or more contiguous pages from the given block of memory
 ///
@@ -78,7 +156,7 @@ physical_address_t page_block_alloc(struct page_block *block, size_t size)
 	bitmap_t *bitmap = block->bitmap;
 
 	start_bit = 0;
-	while (start_bit < block->pages) {
+	while (start_bit < block->total_pages) {
 		if (bitmap[BIT_INDEX(start_bit)] == ALL_PAGES_AT_INDEX) {
 			// If all bits are allocated, move to the next index
 			start_bit += PAGES_PER_INDEX;
@@ -87,7 +165,7 @@ physical_address_t page_block_alloc(struct page_block *block, size_t size)
 			start_bit++;
 		} else {
 			// Attempt to find `contiguous_pages` free bits, or restart at the next `start_bit`
-			for (end_bit = start_bit + 1; end_bit < block->pages && end_bit - start_bit < contiguous_pages; end_bit++) {
+			for (end_bit = start_bit + 1; end_bit < block->total_pages && end_bit - start_bit < contiguous_pages; end_bit++) {
 				// Break early if we didn't find enough bits
 				if ((bitmap[BIT_INDEX(end_bit)] & BIT_MASK(end_bit)) != 0) {
 					break;
@@ -95,7 +173,7 @@ physical_address_t page_block_alloc(struct page_block *block, size_t size)
 			}
 
 			// If not enough pages were found, then restart at the next start bit
-			if (end_bit > block->pages || end_bit - start_bit < contiguous_pages) {
+			if (end_bit > block->total_pages || end_bit - start_bit < contiguous_pages) {
 				start_bit++;
 				continue;
 			}
@@ -104,12 +182,13 @@ physical_address_t page_block_alloc(struct page_block *block, size_t size)
 			for (bit = start_bit; bit < end_bit; bit++) {
 				#if defined(CONFIG_MMU)
 				block->page_descriptors[bit].refcount = 1;
-				log_trace("allocated page %x\n", &block->base[bit]);
+				log_trace("allocated page %x\n", &((page_t *) block->base)[bit]);
 				#endif
 				bitmap[BIT_INDEX(bit)] |= BIT_MASK(bit);
 			}
+			block->free_pages -= contiguous_pages;
 
-			return (physical_address_t) &block->base[start_bit];
+			return (physical_address_t) &((page_t *) block->base)[start_bit];
 		}
 	}
 
@@ -122,7 +201,7 @@ void page_block_free(struct page_block *block, physical_address_t ptr, size_t si
 
 	for (; size >= PAGE_SIZE; page_number++, size -= PAGE_SIZE) {
 		#if defined(CONFIG_MMU)
-		log_trace("decrement refcount for %x to %d\n", &block->base[page_number], block->page_descriptors[page_number].refcount - 1);
+		log_trace("decrement refcount for %x to %d\n", &((page_t *) block->base)[page_number], block->page_descriptors[page_number].refcount - 1);
 		if (--block->page_descriptors[page_number].refcount != 0) {
 			continue;
 		}
@@ -130,6 +209,7 @@ void page_block_free(struct page_block *block, physical_address_t ptr, size_t si
 
 		int index = BIT_INDEX(page_number);
 		block->bitmap[index] &= ~(BIT_MASK(page_number));
+		block->free_pages += 1;
 	}
 }
 
@@ -140,7 +220,7 @@ physical_address_t page_block_make_ref(struct page_block *block, physical_addres
 
 	for (; size >= PAGE_SIZE; page_number++, size -= PAGE_SIZE) {
 		block->page_descriptors[page_number].refcount++;
-		log_trace("increment refcount for %x to %d\n", &block->base[page_number], block->page_descriptors[page_number].refcount);
+		log_trace("increment refcount for %x to %d\n", &((page_t *) block->base)[page_number], block->page_descriptors[page_number].refcount);
 	}
 	return ptr;
 }

--- a/src/kernel/proc/init.c
+++ b/src/kernel/proc/init.c
@@ -186,7 +186,7 @@ int alloc_kernel_stack(struct process *proc, int (*thread_start)(), const char *
 	char *stack;
 
 	// Allocate a new stack, which doesn't have to be mapped, because the kernel map has all of memory mapped 1:1
-	stack = (char *) page_alloc(PAGE_SIZE);
+	stack = (char *) page_alloc(PAGE_SIZE, PAGE_F_SUPERVISOR);
 	proc->map->sbrk = (uintptr_t) stack;
 	proc->map->stack_end = (uintptr_t) stack + PAGE_SIZE;
 

--- a/tests/kernel/mm/pages_test.c
+++ b/tests/kernel/mm/pages_test.c
@@ -23,7 +23,7 @@ int test_page_single_allocation(void)
 
 	struct page_block block;
 
-	init_page_block(&block, (void *) base, SIZE);
+	init_page_block(&block, (physical_address_t) base, SIZE, 0);
 
 	// NOTE: ADDR(0x1000) should be the first non-bitmap page, and there should only be 7 available pages
 	assert(page_block_alloc(&block, PAGE_SIZE) == (physical_address_t) ADDR(1 * PAGE_SIZE));
@@ -59,7 +59,7 @@ int test_page_contiguous_allocation(void)
 
 	struct page_block block;
 
-	init_page_block(&block, (void *) base, SIZE);
+	init_page_block(&block, (physical_address_t) base, SIZE, 0);
 
 	// NOTE: ADDR(0x1000) should be the first non-bitmap page, and there should only be 7 available pages
 	assert(page_block_alloc(&block, 1 * PAGE_SIZE) == (physical_address_t) ADDR(1 * PAGE_SIZE));

--- a/todo.txt
+++ b/todo.txt
@@ -1,65 +1,71 @@
 
-* add page_alloc flags, and convert the page alloc macros into functions that allocate from a block that matches the requested flags
-* make it possible to use membird memory card vs onboard cpu memory based on flags, and somehow make it possible to select that at runtime?  Is there a posix standard or something for that or just using different allocators?
+* make better use of the flags, so that it can run both on a single block system, and multi-block, with global offboard memory
+* add stats of some kind to the page allocator?  Where would the data be displayed, in procfs?
+* add flags to kmalloc too?
 
 * normalize using start/end vs start/length (or the other way around?)  Which way?  Length avoids the edgecase of end, but end saves on an addition each step?  Maybe not worth it when you have to do an extra comparison
 * need to make language consistent, duplicate vs clone vs something better?  alloc vs ?  make_ref vs clone? free vs release?
+* should you rename vfs_clone_vnode/vfs_release_vnode to instead be vfs_clone_vnode_ref/vfs_drop_vnode_ref ??  The latter would make more sense, albeit be longer
 
 * add -Wextra, even though it doesn't seem to catch all the type size issues.  I have to specifically request -Wconversion in order to get the warning I want, but it's over zealous
 
 * bug where, when a file already exists, and you use truncate ">" in the shell, it drops the first letter for some reason (might also be quote parsing in echo)
+* when there's a trailing / to rm or mkdir, it will create something weird
 
 * add a page cache/file cache for file data
 * convert bufcache/disk blocks to use pages
 
 ----
 
-* refactor queue and ringbuffer, try not inlining everything to see if significantly reduces the size
-* for queue, make it possible/easier to have multiple nodes in the same struct
-* change LF to CR+LF (or make it configurable) in the TTY driver.  The computer should send CR+LF whenever an LF is sent by a user program (unless raw enabled), and CR characters should be ignored, so the terminal could send CR+LF or LF
-
-* why does procfs use dev=1?  Can I avoid that hack somehow?
-* make the tty sub-drivers more integrated into the tty parent driver, to make it easier to swap out.  Put common stuff in kernel/drivers/tty.h
-* make the slip's tty device configurable
-* send doesn't work because when it switches to not ICANON and not ECHO, the process is suspended and never wakes up
-
-* fix docker config
-
-* add a way of registering filesystem types instead of what you have now?  I mean, it would allow you to validate each filesystem entry like I'm doing now for drivers, but adds overhead when a static array works fine for now otherwise
-* go through things that use fixed-size tables and make them use kmalloc, or at least use kmalloc for the table itself, with resizing
-
-* there's a bug when running (nettest and then?) daemon when the MMU is enabled and the shell is compiled into the kernel
-* you should put in a limit to the iterator size created for the stack, in exec, context, etc
-* should you move the reference increment to inside memory_map_mmap?  It would be a bit weird in that a file/region passed into mmap would not have the reference captured, but
-  instead expect the caller to still free their own reference.  Most other functions don't operate like that
-
-* make tracing logs module-selectable, so not all trace messages get activated
-
-* a bad user space address can crash the kernel with a page fault. Need to improve the MMU recovery mechanism, and also add address validation to no-MMU
-* the problem with making the user stack use all of memory is actually that it preallocates the tables which takes way too long, so maybe you need to
-  only allocate part of the stack at the top of memory, and grow the stack on demand, or else make it so that the entire tree isn't filled out until needed
-
-* add multiple blocks of pages to the page allocator, along with stats (have to also fix kmem alloc)
-* make everything that uses iters check for errors
-* make everything that uses usercopy functions check for errors
-* replace user_buf with iovec iter type? (and add syscalls for userland iovec read/write funcs?)
-* add flags to kmalloc/page alloc?
-
 * I think there's a bug where if you start the httpd server (at least in daemon mode), and then kill it and run it again, it will fail with error -43, address in use
 * the error -43 address in use error also corresponds to ps no longer working.  I haven't verified if it's all fs functions, or just procfs
 * figure out why signals are broken, this is where `sh` will exit instead of supressing the signal with custom handler
   it seems to only affect some things, namely when sh is compiled into the kernel
 * why does malloc "out of memory" cause the OS to lock up instead of just terminating the process?
+* a bad user space address can crash the kernel with a page fault. Need to improve the MMU recovery mechanism, and also add address validation to no-MMU
+* the problem with making the user stack use all of memory is actually that it preallocates the tables which takes way too long, so maybe you need to
+  only allocate part of the stack at the top of memory, and grow the stack on demand, or else make it so that the entire tree isn't filled out until needed
+
+* fix docker config
+* make a dockerfile that can also compile the entire project
+* make tracing logs module-selectable, so not all trace messages get activated
 
 * [breaking change] re-adjust the syscall numbers, which will be a breaking change and I'll need to update my compactflash card
 
-* make a dockerfile that can also compile the entire project
+* need a function to convert a device number into a device name or device file path. (Could add another driver function pointer for getting the name of a devnum) (add to /proc/mounts)
+  this is partially implemented, but perhaps I need a way to ask the driver to write to a string, since right now, it's assuming the minor number will always be a diget.  For something
+  like procfs, it doesn't print correctly
+* you should put in a limit to the iterator size created for the stack, in exec, context, etc
+* change LF to CR+LF (or make it configurable) in the TTY driver.  The computer should send CR+LF whenever an LF is sent by a user program (unless raw enabled), and CR characters should be ignored, so the terminal could send CR+LF or LF
 
-----
+* refactor queue and ringbuffer, try not inlining everything to see if significantly reduces the size
+* go through things that use fixed-size tables and make them use kmalloc, or at least use kmalloc for the table itself, with resizing: drivers, bottom half, slip devices, tty devices, ata, mem, fileptr table, vnode tables
+
+* make the tty sub-drivers more integrated into the tty parent driver, to make it easier to swap out.  Put common stuff in kernel/drivers/tty.h
+* make the slip's tty device configurable
+* send doesn't work because when it switches to not ICANON and not ECHO, the process is suspended and never wakes up
+
+* there's a bug when running (nettest and then?) daemon when the MMU is enabled and the shell is compiled into the kernel
+* test the read-only filesystem mounting better
+
+* should you move the reference increment to inside memory_map_mmap?  It would be a bit weird in that a file/region passed into mmap would not have the reference captured, but
+  instead expect the caller to still free their own reference.  Most other functions don't operate like that
+
+* make everything that uses iters check for errors
+* make everything that uses usercopy functions check for errors
+* replace user_buf with iovec iter type? (and add syscalls for userland iovec read/write funcs?)
 
 * I need like an lsof command to list at least open files for the current process? or add it to procfs?
 * separate access control paramater (rwx) to mmu_table_mmap, and map_memory_mmap??
+
+----
+
+* why does procfs use dev=1?  Can I avoid that hack somehow?
+* the process should wait until all output is flushed before it can exit
+* make it so the ata device will time out and fail instead of hanging when it doesn't work
 * I'd like to make the ringbuffer use a better way of determining size, without a gotcha, perhaps by having multiple init functions?
+* add a way of registering filesystem types instead of what you have now?  I mean, it would allow you to validate each filesystem entry
+  like I'm doing now for drivers, but adds overhead when a static array works fine for now otherwise
 
 * should you make each drivers/ subdir be its own subsystem with a common set of things, and then the specific drivers within directories
 * as part of this, block drivers would have their own block-specific driver interface, and tty would be the character device interface
@@ -76,15 +82,6 @@
 * see if changing queues, ringbuffer, etc to non-inline functions reduces code size
 * make it possible to get a really small memory-usage kernel, at least with specific configurations
 
-* the process should wait until all output is flushed before it can exit
-* should you split the context switch so that it doesn't change the kernel stack unless needed, and then the full context switch can happen
-  much later inside the kernel?  I have a feeling I'd need to refactor how locks work in order to make this feasible
-
-* is there value in making the code conform to a particular C standard?
-* add configuration for base address in linker script
-* make it so the ata device will time out and fail instead of hanging when it doesn't work
-* add an emulator that can run the bare tests
-
 
 Overview
 
@@ -92,16 +89,22 @@ Overview
     * add multi-cpu support
     * add dynamic linking
     * add additional architectures?
+    * add dns support
 
     * omg write so much documentation.  This needs documentation, and autodoc building.  What's the C standard (ish, defacto?) for doc comments
 
 
 Operating System:
 
+    * is there value in making the code conform to a particular C standard?
+    * add an emulator that can run the bare tests
+
     * support minixfs 2 and 3?
     * should you support large pages?
     * add kernel threads?  the need to use only one stack might be troublesome, especially making it work in all possible configs (nouser, user, mmu)
 
+    * should you split the context switch so that it doesn't change the kernel stack unless needed, and then the full context switch can happen
+      much later inside the kernel?  I have a feeling I'd need to refactor how locks work in order to make this feasible
     * implement the shadow memory solution from Minix/Fuzix for the issue of forking processes without MMU, where the addresses are
       not patched and point to the old processes memory space.  Both OSes copy a shadow data segment into the parent process's
       memory segments so that the process will see its own data instead of sharing data with the parent.  Since most processes that
@@ -113,21 +116,17 @@ Operating System:
     * something is causing the SLIP serial port to mess up somehow which requires restarting the PC side the setup, It's probably a null characters when turning the device on or off
     * make the tty68681 driver partially write data... right now it'll suspend if the full request can't be buffered, but it should return the partial number, and the read/write syscalls should do
       the actual blocking, and then for writing it can rewrite the syscall during the suspend, so that it'll restart in the proper position.  You then need to add resuming to tty
-    * when there's a trailing / to rm or mkdir, it will create something weird
 
     * add dynamic linking so that you can have a shared libc
 
     * it's hacky, but the two create directory things work for now.  I'd like to fix the libc one, I guess by properly converting the whole thing to the new build system?
     * should you replace the libc makefile with subdirs like the kernel?
     * make a better clean rule?
-    * add select-config rule to copy existing config?
 
     * add timers and retransmissions to tcp
     * try transfering files over tcp, to test the stability of TCP (it should be possible to `nc -l 3904 > tar -x` or something to transfer data)
     * make checksum command for file integrity
-    * add a read only mounting mode, such that you know you wont need to sync while also not messing up the CF card
     * should there be something that periodically syncs data to disk?
-    * need a function to convert a device number into a device name or device file path. (Could add another driver function pointer for getting the name of a devnum) (add to /proc/mounts)
     * add calculating of cpu runtime
 
 
@@ -140,14 +139,12 @@ Operating System:
     * signals like SIGTTOU are supposed to be sent sometimes instead of returning success or failure
     * do you need to implement some internal network routing?
 
-    * should you rename vfs_clone_vnode/vfs_release_vnode to instead be vfs_clone_vnode_ref/vfs_drop_vnode_ref ??  The latter would make more sense, albeit be longer
     * you could possibly make an abstracted packet construction thing using an ioctl-like function defined for each protocol, which can intercept parts of
       the requests to fill in data in the packet headers (set src address, set dest address, add id, etc)
     * should you separate libc, kernel, and monitor into their own subproject directories with the include files separated?  Each could use the same build system and
       config system, maybe with some modifications so that CCFLAGS can be defined for a whole subdirectory for the project-specific includes.  It would make it easier
       to use only parts of it, like use libc in other projects, or take just the kernel (monitor doesn't have its own includes outside of itself, so it isn't so relevant)
 
-    * implement dns
     * add pipe setup to command evaluation
     * add the & (run in background) option to the shell
     * add support for * in shell
@@ -157,7 +154,7 @@ Operating System:
     * add stack guard protection
     * implement login system (setuid)
     * implement fcntl
-    * implement symlinks in minixfs
+    * implement symlinks
     * optionally implement ftell, fgetpos, fsetpos
     * can you implement some kind of terminal switching, like alt-F* keys... It would have to be more like `screen`
     * make a /dev/flash0 device or /dev/rom0 device in the mem.c driver, possibly even with a partition table and bootloader, that can be mounted read only
@@ -174,15 +171,11 @@ Operating System:
 
     * should you add timestamps to packets? (not currently a use for it)
     * rewrite the math functions to use fewer registers, and cover the 32 bit divide by 32 bit number case
-    * minixfs, implement versions 2 and 3
-    * should you refactor the header files in minixfs implementation into actual c files, with a common header to declare the functions?
-    * do you need to add variable sized buffers/blocks into bufcache? (yes)
     * can you change the fd allocator, such that calling it twice will return 2 different fds, even though they aren't reserved until set
       (ie. store the last allocated fd, but it has to be in the process struct)
 
     * there is an issue running the shell on linux related to the setting the process group
     * re-evaluate file permissions checks to make sure they're correct according to posix
-    * you need some tests, but ideally it would use a simple emulator.  Maybe easy68k or something could be used
 
     * as a note about terminology for pseudoterminals, pts/ptm (slave/master);  it would make more sense for them to be named process-end and device-end, which implies
       the expected interface to each.   A user process will open the process-end terminal device and communicate with it like any tty.  The emulator or whatever would


### PR DESCRIPTION
It's now possible to add more than one block of memory to a list of blocks, and have the allocator use flags in each block to determine where a page of memory should be allocated from.  This is still a long way from where I'd like it to be, in order to support the NUMA architecture of retroverse, but it's a step towards that.